### PR TITLE
Adds GUI to toggle live update of sigma in density plot

### DIFF
--- a/src/DensityPlotAction.h
+++ b/src/DensityPlotAction.h
@@ -25,8 +25,10 @@ public:
 
 protected:
     DecimalAction       _sigmaAction;
+    ToggleAction        _continuousUpdatesAction;
 
     static constexpr double DEFAULT_SIGMA = 25.0;
+    static constexpr bool DEFAULT_CONTINUOUS_UPDATES = true;
 
     friend class Widget;
     friend class PlotAction;


### PR DESCRIPTION
I think depending on a fixed number of points for this does not make a lot of sense, so I added a toggle action. It defaults to live updates on, as I think this should be fast enough on a decent GPU for millions of points.