### PR TITLE
adjust cmake binary to make it work if not the top level project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ install(TARGETS ${PROJECT}
 
 add_custom_command(TARGET ${PROJECT} POST_BUILD
     COMMAND "${CMAKE_COMMAND}"
-        --install ${CMAKE_BINARY_DIR}
+        --install ${CMAKE_CURRENT_BINARY_DIR}
         --config $<CONFIGURATION>
         --prefix ${INSTALL_DIR}/$<CONFIGURATION>
 )


### PR DESCRIPTION
When using the DevBundle I noticed that the cmake variable in the install command had to be adjusted.
