### PR TITLE
Implements macOS hi dpi display support

### DIFF
--- a/src/ScatterplotWidget.h
+++ b/src/ScatterplotWidget.h
@@ -229,6 +229,9 @@ signals:
 
 public slots:
     void computeDensity();
+    
+private slots:
+    void updatePixelRatio();
 
 private:
     const Matrix3f          toClipCoordinates = Matrix3f(2, 0, 0, 2, -1, -1);
@@ -244,4 +247,5 @@ private:
     Bounds                  _dataBounds;                        /** Bounds of the loaded data */
     QImage                  _colorMapImage;
     PixelSelectionTool      _pixelSelectionTool;
+    float                   _pixelRatio;
 };


### PR DESCRIPTION
These changes implement hi dpi display support on macOS (issue https://github.com/ManiVaultStudio/Scatterplot/issues/5).

This is done by requesting pixelRatio from containing window and use it to scale the opengl view parameters.
This also includes catching the qt screenChanged signal for the current window to handle movement of the view from a low to a hi dpi display or vice versa.

This is only tested on macOS. Please check if the renderer still works as expected on Windows and Linux.