### PR TITLE
Fix window handling on linux

### DIFF
--- a/src/PointPlotAction.cpp
+++ b/src/PointPlotAction.cpp
@@ -173,8 +173,6 @@ QMenu* PointPlotAction::getContextMenu()
 
     auto menu = new QMenu("Plot settings");
 
-    const auto renderMode = _scatterplotPlugin->getScatterplotWidget().getRenderMode();
-
     const auto addActionToMenu = [menu](QAction* action) {
         auto actionMenu = new QMenu(action->text());
 

--- a/src/PositionAction.cpp
+++ b/src/PositionAction.cpp
@@ -32,17 +32,6 @@ PositionAction::PositionAction(QObject* parent, const QString& title) :
         scatterplotPlugin->setYDimension(currentDimensionIndex);
     });
 
-    connect(&scatterplotPlugin->getPositionDataset(), &Dataset<Points>::changed, this, [this, scatterplotPlugin]() {
-        _xDimensionPickerAction.setPointsDataset(scatterplotPlugin->getPositionDataset());
-        _yDimensionPickerAction.setPointsDataset(scatterplotPlugin->getPositionDataset());
-
-        _xDimensionPickerAction.setCurrentDimensionIndex(0);
-
-        const auto yIndex = _xDimensionPickerAction.getNumberOfDimensions() >= 2 ? 1 : 0;
-
-        _yDimensionPickerAction.setCurrentDimensionIndex(yIndex);
-    });
-
     connect(&scatterplotPlugin->getPositionDataset(), &Dataset<Points>::dataDimensionsChanged, this, [this, scatterplotPlugin]() {
         // if the new number of dimensions allows it, keep the previous dimension indices
         auto xDim = _xDimensionPickerAction.getCurrentDimensionIndex();
@@ -73,7 +62,19 @@ PositionAction::PositionAction(QObject* parent, const QString& title) :
 
     updateReadOnly();
 
-    connect(&scatterplotPlugin->getPositionDataset(), &Dataset<Points>::changed, this, updateReadOnly);
+    connect(&scatterplotPlugin->getPositionDataset(), &Dataset<Points>::changed, this, [this, scatterplotPlugin, updateReadOnly](mv::DatasetImpl* dataset) {
+        updateReadOnly();
+
+        _xDimensionPickerAction.setPointsDataset(scatterplotPlugin->getPositionDataset());
+        _yDimensionPickerAction.setPointsDataset(scatterplotPlugin->getPositionDataset());
+
+        _xDimensionPickerAction.setCurrentDimensionIndex(0);
+
+        const auto yIndex = _xDimensionPickerAction.getNumberOfDimensions() >= 2 ? 1 : 0;
+
+        _yDimensionPickerAction.setCurrentDimensionIndex(yIndex);
+    });
+
 }
 
 QMenu* PositionAction::getContextMenu(QWidget* parent /*= nullptr*/)

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -446,8 +446,7 @@ void ScatterplotPlugin::loadColors(const Dataset<Points>& points, const std::uin
     }
 
     // Populate point scalars
-    if (dimensionIndex >= 0)
-        points->extractDataForDimension(scalars, dimensionIndex);
+    points->extractDataForDimension(scalars, dimensionIndex);
 
     // Assign scalars and scalar effect
     _scatterPlotWidget->setScalars(scalars);

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -38,12 +38,12 @@ using namespace mv::util;
 
 ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
     ViewPlugin(factory),
+    _dropWidget(nullptr),
+    _scatterPlotWidget(new ScatterplotWidget()),
     _positionDataset(),
     _positionSourceDataset(),
     _positions(),
     _numPoints(0),
-    _scatterPlotWidget(new ScatterplotWidget()),
-    _dropWidget(nullptr),
     _settingsAction(this, "Settings"),
     _primaryToolbarAction(this, "Primary Toolbar"),
     _secondaryToolbarAction(this, "Secondary Toolbar"),

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -559,7 +559,7 @@ void ScatterplotPlugin::updateSelection()
 
     highlights.resize(_positionDataset->getNumPoints(), 0);
 
-    for (int i = 0; i < selected.size(); i++)
+    for (std::size_t i = 0; i < selected.size(); i++)
         highlights[i] = selected[i] ? 1 : 0;
 
     _scatterPlotWidget->setHighlights(highlights, static_cast<std::int32_t>(selection->indices.size()));

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -538,6 +538,7 @@ void ScatterplotPlugin::updateData()
         updateSelection();
     }
     else {
+        _numPoints = 0;
         _positions.clear();
         _scatterPlotWidget->setData(&_positions);
     }

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -531,7 +531,7 @@ void ScatterplotPlugin::updateData()
         _numPoints = _positionDataset->getNumPoints();
 
         // Extract 2-dimensional points from the data set based on the selected dimensions
-        calculatePositions(*_positionDataset);
+        _positionDataset->extractDataForDimensions(_positions, xDim, yDim);
 
         // Pass the 2D points to the scatter plot widget
         _scatterPlotWidget->setData(&_positions);
@@ -542,11 +542,6 @@ void ScatterplotPlugin::updateData()
         _positions.clear();
         _scatterPlotWidget->setData(&_positions);
     }
-}
-
-void ScatterplotPlugin::calculatePositions(const Points& points)
-{
-    points.extractDataForDimensions(_positions, _settingsAction.getPositionAction().getDimensionX(), _settingsAction.getPositionAction().getDimensionY());
 }
 
 void ScatterplotPlugin::updateSelection()

--- a/src/ScatterplotPlugin.h
+++ b/src/ScatterplotPlugin.h
@@ -114,20 +114,22 @@ public: // Serialization
     QVariantMap toVariantMap() const override;
 
 private:
+    mv::gui::DropWidget*            _dropWidget;                /** Widget for dropping datasets */
+    ScatterplotWidget*              _scatterPlotWidget;         /** THe visualization widget */
+
     Dataset<Points>                 _positionDataset;           /** Smart pointer to points dataset for point position */
     Dataset<Points>                 _positionSourceDataset;     /** Smart pointer to source of the points dataset for point position (if any) */
-    std::vector<mv::Vector2f>     _positions;                 /** Point positions */
+    std::vector<mv::Vector2f>       _positions;                 /** Point positions */
     unsigned int                    _numPoints;                 /** Number of point positions */
+
+    SettingsAction                  _settingsAction;            /** Group action for all settings */
+    HorizontalToolbarAction         _primaryToolbarAction;      /** Horizontal toolbar for primary content */
+    HorizontalToolbarAction         _secondaryToolbarAction;    /** Secondary toolbar for secondary content */
+
     QTimer                          _selectPointsTimer;         /** Timer to limit the refresh rate of selection updates */
 
     static const std::int32_t LAZY_UPDATE_INTERVAL = 2;
 
-protected:
-    ScatterplotWidget*          _scatterPlotWidget;         /** THe visualization widget */
-    mv::gui::DropWidget*      _dropWidget;                /** Widget for dropping datasets */
-    SettingsAction              _settingsAction;            /** Group action for all settings */
-    HorizontalToolbarAction     _primaryToolbarAction;      /** Horizontal toolbar for primary content */
-    HorizontalToolbarAction     _secondaryToolbarAction;    /** Secondary toolbar for secondary content */
 };
 
 // =============================================================================

--- a/src/ScatterplotPlugin.h
+++ b/src/ScatterplotPlugin.h
@@ -97,7 +97,6 @@ public:
 
 private:
     void updateData();
-    void calculatePositions(const Points& points);
     void updateSelection();
 
 public: // Serialization

--- a/src/ScatterplotWidget.cpp
+++ b/src/ScatterplotWidget.cpp
@@ -35,9 +35,15 @@ namespace
 
 ScatterplotWidget::ScatterplotWidget() :
     QOpenGLWidget(),
-    _densityRenderer(DensityRenderer::RenderMode::DENSITY),
-    _backgroundColor(1, 1, 1),
     _pointRenderer(),
+    _densityRenderer(DensityRenderer::RenderMode::DENSITY),
+    _isInitialized(false),
+    _renderMode(SCATTERPLOT),
+    _backgroundColor(1, 1, 1),
+    _coloringMode(ColoringMode::Constant),
+    _windowSize(),
+    _dataBounds(),
+    _colorMapImage(),
     _pixelSelectionTool(this),
     _pixelRatio(1.0)
 {

--- a/src/ScatterplotWidget.cpp
+++ b/src/ScatterplotWidget.cpp
@@ -45,8 +45,6 @@ ScatterplotWidget::ScatterplotWidget() :
     setMouseTracking(true);
     setFocusPolicy(Qt::ClickFocus);
 
-    _pointRenderer.setPointScaling(Absolute);
-
     // Configure pixel selection tool
     _pixelSelectionTool.setEnabled(true);
     _pixelSelectionTool.setMainColor(QColor(Qt::black));
@@ -507,6 +505,7 @@ void ScatterplotWidget::initializeGL()
     // Set a default color map for both renderers
     _pointRenderer.setScalarEffect(PointEffect::Color);
 
+    _pointRenderer.setPointScaling(Absolute);
     _pointRenderer.setSelectionOutlineColor(Vector3f(1, 0, 0));
 
     // OpenGL is initialized

--- a/src/ScatterplotWidget.cpp
+++ b/src/ScatterplotWidget.cpp
@@ -528,19 +528,6 @@ void ScatterplotWidget::resizeGL(int w, int h)
 
     _pointRenderer.resize(QSize(w, h));
     _densityRenderer.resize(QSize(w, h));
-
-    // Set matrix for normalizing from pixel coordinates to [0, 1]
-    toNormalisedCoordinates = Matrix3f(1.0f / w, 0, 0, 1.0f / h, 0, 0);
-
-    // Take the smallest dimensions in order to calculate the aspect ratio
-    int size = w < h ? w : h;
-
-    float wAspect = (float)w / size;
-    float hAspect = (float)h / size;
-    float wDiff = ((wAspect - 1) / 2.0);
-    float hDiff = ((hAspect - 1) / 2.0);
-
-    toIsotropicCoordinates = Matrix3f(wAspect, 0, 0, hAspect, -wDiff, -hDiff);
 }
 
 void ScatterplotWidget::paintGL()

--- a/src/ScatterplotWidget.cpp
+++ b/src/ScatterplotWidget.cpp
@@ -38,7 +38,7 @@ ScatterplotWidget::ScatterplotWidget() :
     _densityRenderer(DensityRenderer::RenderMode::DENSITY),
     _isInitialized(false),
     _renderMode(SCATTERPLOT),
-    _backgroundColor(1, 1, 1),
+    _backgroundColor(255, 255, 255, 255),
     _coloringMode(ColoringMode::Constant),
     _windowSize(),
     _dataBounds(),

--- a/src/ScatterplotWidget.cpp
+++ b/src/ScatterplotWidget.cpp
@@ -1,7 +1,6 @@
 #include "ScatterplotWidget.h"
 #include "Application.h"
 
-#include "util/PixelSelectionTool.h"
 #include "util/Math.h"
 #include "util/Exception.h"
 
@@ -100,7 +99,7 @@ ScatterplotWidget::ScatterplotWidget() :
     });
 }
 
-bool ScatterplotWidget::isInitialized()
+bool ScatterplotWidget::isInitialized() const
 {
     return _isInitialized;
 }
@@ -547,9 +546,6 @@ void ScatterplotWidget::resizeGL(int w, int h)
 void ScatterplotWidget::paintGL()
 {
     try {
-        const auto areaPixmap   = _pixelSelectionTool.getAreaPixmap();
-        const auto shapePixmap  = _pixelSelectionTool.getShapePixmap();
-
         QPainter painter;
 
         // Begin mixed OpenGL/native painting
@@ -588,6 +584,8 @@ void ScatterplotWidget::paintGL()
         
         // Draw the pixel selection tool overlays if the pixel selection tool is enabled
         if (_pixelSelectionTool.isEnabled()) {
+            const auto areaPixmap   = _pixelSelectionTool.getAreaPixmap();
+            const auto shapePixmap  = _pixelSelectionTool.getShapePixmap();
             painter.drawPixmap(rect(), areaPixmap);
             painter.drawPixmap(rect(), shapePixmap);
         }

--- a/src/ScatterplotWidget.cpp
+++ b/src/ScatterplotWidget.cpp
@@ -34,6 +34,7 @@ namespace
 }
 
 ScatterplotWidget::ScatterplotWidget() :
+    QOpenGLWidget(),
     _densityRenderer(DensityRenderer::RenderMode::DENSITY),
     _backgroundColor(1, 1, 1),
     _pointRenderer(),
@@ -55,27 +56,16 @@ ScatterplotWidget::ScatterplotWidget() :
     });
 
     QSurfaceFormat surfaceFormat;
-
     surfaceFormat.setRenderableType(QSurfaceFormat::OpenGL);
-
-    // Ask for an different OpenGL versions depending on OS
-#if defined(__APPLE__) 
-    surfaceFormat.setVersion(3, 3); // https://support.apple.com/en-us/101525
+    surfaceFormat.setVersion(3, 3); 
     surfaceFormat.setProfile(QSurfaceFormat::CoreProfile);
-#elif defined(__linux__ )
-    surfaceFormat.setVersion(4, 2); // glxinfo | grep "OpenGL version"
-    surfaceFormat.setProfile(QSurfaceFormat::CompatibilityProfile);
-#else
-    surfaceFormat.setVersion(4, 3);
-    surfaceFormat.setProfile(QSurfaceFormat::CoreProfile);
-#endif
+    surfaceFormat.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
+    surfaceFormat.setSamples(16);
+    surfaceFormat.setStencilBufferSize(8);
 
 #ifdef _DEBUG
     surfaceFormat.setOption(QSurfaceFormat::DebugContext);
 #endif
-
-    surfaceFormat.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
-    surfaceFormat.setSamples(16);
 
     setFormat(surfaceFormat);
     

--- a/src/ScatterplotWidget.h
+++ b/src/ScatterplotWidget.h
@@ -11,7 +11,7 @@
 #include "graphics/Selection.h"
 
 #include <QOpenGLWidget>
-#include <QOpenGLFunctions>
+#include <QOpenGLFunctions_3_3_Core>
 
 #include <QMouseEvent>
 #include <QMenu>
@@ -20,7 +20,7 @@ using namespace mv;
 using namespace mv::gui;
 using namespace mv::util;
 
-class ScatterplotWidget : public QOpenGLWidget, protected QOpenGLFunctions
+class ScatterplotWidget : public QOpenGLWidget, protected QOpenGLFunctions_3_3_Core
 {
     Q_OBJECT
 

--- a/src/ScatterplotWidget.h
+++ b/src/ScatterplotWidget.h
@@ -11,7 +11,7 @@
 #include "graphics/Selection.h"
 
 #include <QOpenGLWidget>
-#include <QOpenGLFunctions_3_3_Core>
+#include <QOpenGLFunctions>
 
 #include <QMouseEvent>
 #include <QMenu>
@@ -20,7 +20,7 @@ using namespace mv;
 using namespace mv::gui;
 using namespace mv::util;
 
-class ScatterplotWidget : public QOpenGLWidget, QOpenGLFunctions_3_3_Core
+class ScatterplotWidget : public QOpenGLWidget, protected QOpenGLFunctions
 {
     Q_OBJECT
 

--- a/src/ScatterplotWidget.h
+++ b/src/ScatterplotWidget.h
@@ -191,6 +191,12 @@ protected:
     void paintGL()              Q_DECL_OVERRIDE;
     void cleanup();
     
+    void showEvent(QShowEvent* event) Q_DECL_OVERRIDE
+    {
+        emit created();
+        QWidget::showEvent(event);
+    }
+
 public: // Const access to renderers
 
     const PointRenderer& getPointRenderer() const { 
@@ -208,6 +214,7 @@ public:
 
 signals:
     void initialized();
+    void created();
 
     /**
      * Signals that the render mode changed

--- a/src/ScatterplotWidget.h
+++ b/src/ScatterplotWidget.h
@@ -243,9 +243,6 @@ private slots:
 private:
     PointRenderer           _pointRenderer;                     
     DensityRenderer         _densityRenderer;                   
-    const Matrix3f          _toClipCoordinates = Matrix3f(2, 0, 0, 2, -1, -1);
-    Matrix3f                toNormalisedCoordinates;
-    Matrix3f                toIsotropicCoordinates;
     bool                    _isInitialized;
     RenderMode              _renderMode;
     QColor                  _backgroundColor;

--- a/src/ScatterplotWidget.h
+++ b/src/ScatterplotWidget.h
@@ -43,7 +43,7 @@ public:
     ~ScatterplotWidget();
 
     /** Returns true when the widget was initialized and is ready to be used. */
-    bool isInitialized();
+    bool isInitialized() const;
 
     /** Get/set render mode */
     RenderMode getRenderMode() const;

--- a/src/ScatterplotWidget.h
+++ b/src/ScatterplotWidget.h
@@ -241,15 +241,15 @@ private slots:
     void updatePixelRatio();
 
 private:
-    const Matrix3f          toClipCoordinates = Matrix3f(2, 0, 0, 2, -1, -1);
-    Matrix3f                toNormalisedCoordinates;
-    Matrix3f                toIsotropicCoordinates;
-    bool                    _isInitialized = false;
-    RenderMode              _renderMode = SCATTERPLOT;
-    QColor                  _backgroundColor;
-    ColoringMode            _coloringMode = ColoringMode::Constant;
     PointRenderer           _pointRenderer;                     
     DensityRenderer         _densityRenderer;                   
+    const Matrix3f          _toClipCoordinates = Matrix3f(2, 0, 0, 2, -1, -1);
+    Matrix3f                toNormalisedCoordinates;
+    Matrix3f                toIsotropicCoordinates;
+    bool                    _isInitialized;
+    RenderMode              _renderMode;
+    QColor                  _backgroundColor;
+    ColoringMode            _coloringMode;
     QSize                   _windowSize;                        /** Size of the scatterplot widget */
     Bounds                  _dataBounds;                        /** Bounds of the loaded data */
     QImage                  _colorMapImage;


### PR DESCRIPTION
I ran into an error on linux along the lines of 

```
QOpenGLContext::makeCurrent() called with non-opengl surface
```

The scatterplot would be all black and not show anything. The culprit seems to be calling `winID()`
https://github.com/ManiVaultStudio/Scatterplot/blob/4823293e68b751c17216f6f414fd4b0c226a6c47/src/ScatterplotWidget.cpp#L87-L88

The problem is both that at the time of calling no window exists yet and (when moving this call to a later point, e.g. after loading a data set via drag&drop) qt on linux handles windows a little different apparently. 

I  solved this by calling the function later and checking if getting the window handle was successful:
https://github.com/ManiVaultStudio/Scatterplot/blob/64f33188fbca637e824bf7dfaa9852b798de7414/src/ScatterplotWidget.cpp#L80-L101

Additionally, I removed the variables 
```cpp
    const Matrix3f          toClipCoordinates = Matrix3f(2, 0, 0, 2, -1, -1);
    Matrix3f                toNormalisedCoordinates;
    Matrix3f                toIsotropicCoordinates;
```
from `ScatterplotWidget` as they were unused.

The other commits are mainly cosmetic and fix warnings.

Tested on Ubuntu 23.10 and Window 11.