### PR TITLE
Update dimensions when dataDimensions change (part 2)

### DIFF
--- a/src/PositionAction.cpp
+++ b/src/PositionAction.cpp
@@ -37,22 +37,22 @@ PositionAction::PositionAction(QObject* parent, const QString& title) :
         auto xDim = _xDimensionPickerAction.getCurrentDimensionIndex();
         auto yDim = _yDimensionPickerAction.getCurrentDimensionIndex();
 
-        _xDimensionPickerAction.setPointsDataset(scatterplotPlugin->getPositionDataset());
-        _yDimensionPickerAction.setPointsDataset(scatterplotPlugin->getPositionDataset());
+        const auto& currentData = scatterplotPlugin->getPositionDataset();
+        const auto numDimensions = static_cast<int32_t>(currentData->getNumDimensions());
 
-        if (static_cast<uint32_t>(xDim) < _xDimensionPickerAction.getNumberOfDimensions())
-            _xDimensionPickerAction.setCurrentDimensionIndex(xDim);
-        else
-            _xDimensionPickerAction.setCurrentDimensionIndex(0);
-
-        if (static_cast<uint32_t>(yDim) < _yDimensionPickerAction.getNumberOfDimensions())
-            _yDimensionPickerAction.setCurrentDimensionIndex(yDim);
-        else
+        if (xDim >= numDimensions || yDim >= numDimensions)
         {
-            const auto yIndex = _xDimensionPickerAction.getNumberOfDimensions() >= 2 ? 1 : 0;
-
-            _yDimensionPickerAction.setCurrentDimensionIndex(yIndex);
+            xDim = 0;
+            yDim = _xDimensionPickerAction.getNumberOfDimensions() >= 2 ? 1 : 0;
+            _xDimensionPickerAction.setCurrentDimensionIndex(xDim);
+            _yDimensionPickerAction.setCurrentDimensionIndex(yDim);
         }
+
+        _xDimensionPickerAction.setPointsDataset(currentData);
+        _yDimensionPickerAction.setPointsDataset(currentData);
+
+        _xDimensionPickerAction.setCurrentDimensionIndex(xDim);
+        _yDimensionPickerAction.setCurrentDimensionIndex(yDim);
 
     });
 

--- a/src/PositionAction.cpp
+++ b/src/PositionAction.cpp
@@ -32,7 +32,15 @@ PositionAction::PositionAction(QObject* parent, const QString& title) :
         scatterplotPlugin->setYDimension(currentDimensionIndex);
     });
 
-    connect(&scatterplotPlugin->getPositionDataset(), &Dataset<Points>::dataDimensionsChanged, this, [this, scatterplotPlugin]() {
+    const auto updateReadOnly = [this, scatterplotPlugin]() -> void {
+        setEnabled(scatterplotPlugin->getPositionDataset().isValid());
+        };
+
+    updateReadOnly();
+
+    connect(&scatterplotPlugin->getPositionDataset(), &Dataset<Points>::dataDimensionsChanged, this, [this, scatterplotPlugin, updateReadOnly]() {
+        updateReadOnly();
+
         // if the new number of dimensions allows it, keep the previous dimension indices
         auto xDim = _xDimensionPickerAction.getCurrentDimensionIndex();
         auto yDim = _yDimensionPickerAction.getCurrentDimensionIndex();
@@ -55,12 +63,6 @@ PositionAction::PositionAction(QObject* parent, const QString& title) :
         _yDimensionPickerAction.setCurrentDimensionIndex(yDim);
 
     });
-
-    const auto updateReadOnly = [this, scatterplotPlugin]() -> void {
-        setEnabled(scatterplotPlugin->getPositionDataset().isValid());
-    };
-
-    updateReadOnly();
 
     connect(&scatterplotPlugin->getPositionDataset(), &Dataset<Points>::changed, this, [this, scatterplotPlugin, updateReadOnly](mv::DatasetImpl* dataset) {
         updateReadOnly();

--- a/src/PositionAction.h
+++ b/src/PositionAction.h
@@ -80,6 +80,8 @@ private:
     DimensionPickerAction    _xDimensionPickerAction;   /** X-dimension picker action */
     DimensionPickerAction    _yDimensionPickerAction;   /** Y-dimension picker action */
 
+    bool                     _dontUpdateScatterplot;
+
     friend class mv::AbstractActionsManager;
 };
 


### PR DESCRIPTION
#107 did not handle all dimension changes correctly, specifically when the number of dimension decreases and then dimension picker is set to a dimension that does not exist anymore.

Now, when this is the case, the scatterplot resets to showing the first and second dimension (and only the first if there is no second dimension)

When dimensions are added, the scatterplot does not change, as before.