### PR TITLE
Connect to changed in color dataset

### DIFF
--- a/src/ColorSourceModel.cpp
+++ b/src/ColorSourceModel.cpp
@@ -1,6 +1,5 @@
 #include "ColorSourceModel.h"
 
-#include <DataHierarchyItem.h>
 #include <Application.h>
 #include <Set.h>
 
@@ -56,6 +55,10 @@ ColorSourceModel::DatasetItem::DatasetItem(Dataset<DatasetImpl> dataset, ColorSo
 
     connect(_dataset.get(), &DatasetImpl::textChanged, this, [this]() {
         emitDataChanged();
+    });
+
+    connect(&_dataset, &Dataset<DatasetImpl>::dataChanged, this, [this]() {
+        _colorSourceModel->dataChanged(_dataset);
     });
 
     connect(_colorSourceModel, &ColorSourceModel::showFullPathNameChanged, this, [this]() {

--- a/src/ColorSourceModel.h
+++ b/src/ColorSourceModel.h
@@ -129,6 +129,8 @@ signals:
      */
     void showFullPathNameChanged(bool showFullPathName);
 
+    void dataChanged(const Dataset<DatasetImpl>& dataset);
+
 protected:
     bool        _showFullPathName;      /** Whether to show the full path name in the GUI */
 


### PR DESCRIPTION
Currently, when coloring by a cluster dataset, the colors are not updated when the cluster data changes.

Steps to reproduce:
1. Show any point data in a Scatterplot
2. Use the MeanShiftPlugin to generate a cluster dataset
3. Drag and drop the cluster dataset on the scatterplot to recolor by clusters
4. Change the sigma value in the MeanShiftPlugin, which updates the clusters. Now, the colors in the Scatterplot should update automatically. Instead, the colors are not updated.

The issue is that, currently, the connection to `dataChanged` in `ColoringAction::addColorDataset` never gets invoked. I'm not entirely sure why, but I think it might be due to temporary reference issues. 
Also, datasets are currently connected multiple times, due to the for loop that is executed each time a new dataset is added: i.e. when a second dataset is added to the model, the first one is connected again.

This PR moves the listening to data changes to the `ColorSourceModel::DatasetItem`. This gets around any temporary reference issues and resolves duplicate connections.