### PR TITLE
Add unity build option 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.17)
 
+option(MV_UNITY_BUILD "Combine target source files into batches for faster compilation" OFF)
+
 # -----------------------------------------------------------------------------
 # Scatterplot Plugin
 # -----------------------------------------------------------------------------
@@ -112,9 +114,6 @@ source_group(Aux FILES ${AUX})
 # -----------------------------------------------------------------------------
 add_library(${PROJECT} SHARED ${SOURCES} ${SHADERS} ${AUX})
 
-qt_wrap_cpp(SCATTERPLOT_MOC ${PLUGIN_MOC_HEADERS} TARGET ${PROJECT})
-target_sources(${PROJECT} PRIVATE ${SCATTERPLOT_MOC})
-
 # -----------------------------------------------------------------------------
 # Target include directories
 # -----------------------------------------------------------------------------
@@ -124,6 +123,10 @@ target_include_directories(${PROJECT} PRIVATE "${MV_INSTALL_DIR}/$<CONFIGURATION
 # Target properties
 # -----------------------------------------------------------------------------
 target_compile_features(${PROJECT} PRIVATE cxx_std_17)
+
+if(MV_UNITY_BUILD)
+    set_target_properties(${PROJECT} PROPERTIES UNITY_BUILD ON)
+endif()
 
 # -----------------------------------------------------------------------------
 # Target library linking

--- a/conanfile.py
+++ b/conanfile.py
@@ -105,6 +105,9 @@ class ScatterplotOPluginConan(ConanFile):
         # Give the installation directory to CMake
         tc.variables["MV_INSTALL_DIR"] = self.install_dir
         
+        # Set some build options
+        tc.variables["MV_UNITY_BUILD"] = "ON"
+
         tc.generate()
 
     def _configure_cmake(self):


### PR DESCRIPTION
Adds optional [unity build](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html): `OFF` by default, except on CI where it's `ON`.