### PR TITLE
Fix 2d colormap colors

### DIFF
--- a/src/ScatterplotWidget.cpp
+++ b/src/ScatterplotWidget.cpp
@@ -121,7 +121,7 @@ ScatterplotWidget::ScatterplotWidget() :
 
         const auto zoomBounds = zoomRectangleAction.getBounds();
 
-        _pointRenderer.setBounds(zoomBounds);
+        _pointRenderer.setBoundsView(zoomBounds);
         _densityRenderer.setBounds(zoomBounds);
 
         _navigationAction.getZoomDataExtentsAction().setEnabled(zoomBounds != _dataRectangleAction.getBounds());
@@ -354,17 +354,24 @@ void ScatterplotWidget::computeDensity()
 // by reference then we can upload the data to the GPU, but not store it in the widget.
 void ScatterplotWidget::setData(const std::vector<Vector2f>* points)
 {
+    _pointRenderer.setData(*points);
+    _densityRenderer.setData(points);
+
     auto dataBounds = getDataBounds(*points);
 
+    // pass un-adjusted data bounds to renderer for 2D colormapping
+    _pointRenderer.setBoundsData(dataBounds);
+
+    // Adjust data points for projection matrix creation (add a little white space around data)
     dataBounds.ensureMinimumSize(1e-07f, 1e-07f);
     dataBounds.makeSquare();
     dataBounds.expand(0.1f);
 
+    _pointRenderer.setBoundsView(dataBounds);
+    _densityRenderer.setBounds(dataBounds);
+
     _dataRectangleAction.setBounds(dataBounds);
     _navigationAction.getZoomRectangleAction().setBounds(dataBounds);
-
-    _pointRenderer.setData(*points);
-    _densityRenderer.setData(points);
 
     switch (_renderMode)
     {

--- a/src/ScatterplotWidget.cpp
+++ b/src/ScatterplotWidget.cpp
@@ -121,7 +121,7 @@ ScatterplotWidget::ScatterplotWidget() :
 
         const auto zoomBounds = zoomRectangleAction.getBounds();
 
-        _pointRenderer.setBoundsView(zoomBounds);
+        _pointRenderer.setViewBounds(zoomBounds);
         _densityRenderer.setBounds(zoomBounds);
 
         _navigationAction.getZoomDataExtentsAction().setEnabled(zoomBounds != _dataRectangleAction.getBounds());
@@ -357,14 +357,14 @@ void ScatterplotWidget::setData(const std::vector<Vector2f>* points)
     auto dataBounds = getDataBounds(*points);
 
     // pass un-adjusted data bounds to renderer for 2D colormapping
-    _pointRenderer.setBoundsData(dataBounds);
+    _pointRenderer.setDataBounds(dataBounds);
 
     // Adjust data points for projection matrix creation (add a little white space around data)
     dataBounds.ensureMinimumSize(1e-07f, 1e-07f);
     dataBounds.makeSquare();
     dataBounds.expand(0.1f);
 
-    _pointRenderer.setBoundsView(dataBounds);
+    _pointRenderer.setViewBounds(dataBounds);
     _densityRenderer.setBounds(dataBounds);
 
     _dataRectangleAction.setBounds(dataBounds);

--- a/src/ScatterplotWidget.cpp
+++ b/src/ScatterplotWidget.cpp
@@ -354,9 +354,6 @@ void ScatterplotWidget::computeDensity()
 // by reference then we can upload the data to the GPU, but not store it in the widget.
 void ScatterplotWidget::setData(const std::vector<Vector2f>* points)
 {
-    _pointRenderer.setData(*points);
-    _densityRenderer.setData(points);
-
     auto dataBounds = getDataBounds(*points);
 
     // pass un-adjusted data bounds to renderer for 2D colormapping
@@ -372,6 +369,9 @@ void ScatterplotWidget::setData(const std::vector<Vector2f>* points)
 
     _dataRectangleAction.setBounds(dataBounds);
     _navigationAction.getZoomRectangleAction().setBounds(dataBounds);
+
+    _pointRenderer.setData(*points);
+    _densityRenderer.setData(points);
 
     switch (_renderMode)
     {


### PR DESCRIPTION
Currently the colormap used for 2D coloring is aligned with the view and not the data.

This leads to (slightly) different colors between the ImageViewer and Scatterplot for the same data and same colormap.

Here, we use the data bounds for the colormap and view bounds for the projection matrix.

Relies on https://github.com/ManiVaultStudio/core/pull/589 for small API changes.