### PR TITLE
Add optional density weighting 

### DIFF
--- a/src/DensityPlotAction.h
+++ b/src/DensityPlotAction.h
@@ -79,11 +79,13 @@ public: // Action getters
 
     DecimalAction& getSigmaAction() { return _sigmaAction; }
     ToggleAction& getContinuousUpdatesAction() { return _continuousUpdatesAction; }
+    ToggleAction& getWeightWithPointSizeAction() { return _weightWithPointSizeAction; }
 
 private:
     ScatterplotPlugin*  _scatterplotPlugin;         /** Pointer to scatterplot plugin */
     DecimalAction       _sigmaAction;               /** Density sigma action */
     ToggleAction        _continuousUpdatesAction;   /** Live updates action */
+    ToggleAction        _weightWithPointSizeAction; /** Use point sizes to weight the density */
 
     static constexpr double DEFAULT_SIGMA = 0.15f;
     static constexpr bool DEFAULT_CONTINUOUS_UPDATES = true;

--- a/src/PlotAction.cpp
+++ b/src/PlotAction.cpp
@@ -20,6 +20,7 @@ PlotAction::PlotAction(QObject* parent, const QString& title) :
     
     addAction(&_densityPlotAction.getSigmaAction());
     addAction(&_densityPlotAction.getContinuousUpdatesAction());
+    addAction(&_densityPlotAction.getWeightWithPointSizeAction());
 }
 
 void PlotAction::initialize(ScatterplotPlugin* scatterplotPlugin)

--- a/src/PointPlotAction.cpp
+++ b/src/PointPlotAction.cpp
@@ -262,7 +262,7 @@ void PointPlotAction::updateScatterPlotWidgetPointSizeScalars()
 
         positionDataset->selectedLocalIndices(positionDataset->getSelection<Points>()->indices, selected);
 
-        for (int i = 0; i < selected.size(); i++) {
+        for (size_t i = 0; i < selected.size(); i++) {
             if (!selected[i])
                 continue;
 

--- a/src/ScatterplotWidget.cpp
+++ b/src/ScatterplotWidget.cpp
@@ -466,6 +466,18 @@ void ScatterplotWidget::setSigma(const float sigma)
     update();
 }
 
+void ScatterplotWidget::setWeightDensity(bool useWeights) 
+{ 
+    _weightDensity = useWeights; 
+
+    const std::vector<float>* weights = nullptr;
+
+    if (_weightDensity)
+        weights = &_pointRenderer.getGpuPoints().getSizeScalars();
+
+    _densityRenderer.setWeights(weights);
+}
+
 mv::Vector3f ScatterplotWidget::getColorMapRange() const
 {
     switch (_renderMode) {

--- a/src/ScatterplotWidget.h
+++ b/src/ScatterplotWidget.h
@@ -130,6 +130,9 @@ public:
     mv::Vector3f getColorMapRange() const;
     void setColorMapRange(const float& min, const float& max);
 
+    void setWeightDensity(bool useWeights);
+    float getWeightDensity() const { return _weightDensity; }
+
     /**
      * Create screenshot
      * @param width Width of the screen shot (in pixels)
@@ -291,6 +294,7 @@ private:
     float                   _pixelRatio;                /** Current pixel ratio */
     QVector<QPoint>         _mousePositions;            /** Recorded mouse positions */
     bool                    _isNavigating;              /** Boolean determining whether view navigation is currently taking place or not */
+    bool                    _weightDensity;             /** Use point scalar sizes to weight density */
 
     friend class NavigationAction;
 };


### PR DESCRIPTION
Implements https://github.com/ManiVaultStudio/core/pull/593

The standard behavior of the density renderer when introducing some point sizes looks the same:
<p align="middle">
  <img src="https://github.com/ManiVaultStudio/core/assets/58806453/3c9f6991-b4df-48b0-8920-b877af61cb4a" align="middle" width="50%" />
</p>

With this PR those size weights can be taken into account in the density renderer:
<p align="middle">
  <img src="https://github.com/ManiVaultStudio/core/assets/58806453/9c681bb4-8938-474b-9689-ca2947f917c5" align="middle" width="50%" />
</p>

Added option (off by default):
<p align="middle">
  <img src="https://github.com/ManiVaultStudio/Scatterplot/assets/58806453/37bdb77f-c9c9-4f00-9206-ad2c42195e4e" align="middle" width="50%" />
</p>

