### PR TITLE
Add support for randomized point depth

### DIFF
--- a/src/MiscellaneousAction.cpp
+++ b/src/MiscellaneousAction.cpp
@@ -10,13 +10,15 @@ const QColor MiscellaneousAction::DEFAULT_BACKGROUND_COLOR = qRgb(255, 255, 255)
 MiscellaneousAction::MiscellaneousAction(QObject* parent, const QString& title) :
     VerticalGroupAction(parent, title),
     _scatterplotPlugin(dynamic_cast<ScatterplotPlugin*>(parent->parent())),
-    _backgroundColorAction(this, "Background color")
+    _backgroundColorAction(this, "Background color"),
+    _randomizedDepthAction(this, "Randomized depth", true)
 {
     setIcon(Application::getIconFont("FontAwesome").getIcon("cog"));
     setLabelSizingType(LabelSizingType::Auto);
     setConfigurationFlag(WidgetAction::ConfigurationFlag::ForceCollapsedInGroup);
 
     addAction(&_backgroundColorAction);
+    addAction(&_randomizedDepthAction);
 
     _backgroundColorAction.setColor(DEFAULT_BACKGROUND_COLOR);
 
@@ -29,6 +31,16 @@ MiscellaneousAction::MiscellaneousAction(QObject* parent, const QString& title) 
     });
 
     updateBackgroundColor();
+
+    const auto updateRandomizedDepth = [this]() -> void {
+        _scatterplotPlugin->getScatterplotWidget().setRandomizedDepthEnabled(_randomizedDepthAction.isChecked());
+    };
+
+    connect(&_randomizedDepthAction, &ToggleAction::toggled, this, [this, updateRandomizedDepth](bool toggled) {
+        updateRandomizedDepth();
+    });
+
+    updateRandomizedDepth();
 }
 
 QMenu* MiscellaneousAction::getContextMenu()
@@ -73,6 +85,7 @@ void MiscellaneousAction::fromVariantMap(const QVariantMap& variantMap)
     GroupAction::fromVariantMap(variantMap);
 
     _backgroundColorAction.fromParentVariantMap(variantMap);
+    _randomizedDepthAction.fromParentVariantMap(variantMap);
 }
 
 QVariantMap MiscellaneousAction::toVariantMap() const
@@ -80,6 +93,7 @@ QVariantMap MiscellaneousAction::toVariantMap() const
     auto variantMap = GroupAction::toVariantMap();
 
     _backgroundColorAction.insertIntoVariantMap(variantMap);
+    _randomizedDepthAction.insertIntoVariantMap(variantMap);
 
     return variantMap;
 }

--- a/src/MiscellaneousAction.h
+++ b/src/MiscellaneousAction.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <actions/ColorAction.h>
 #include <actions/VerticalGroupAction.h>
+#include <actions/ColorAction.h>
+#include <actions/ToggleAction.h>
 
 using namespace mv::gui;
 
@@ -65,10 +66,12 @@ public: // Serialization
 public: // Action getters
 
     ColorAction& getBackgroundColorAction() { return _backgroundColorAction; }
+    ToggleAction& getRandomizedDepthAction() { return _randomizedDepthAction; }
 
 private:
     ScatterplotPlugin*  _scatterplotPlugin;         /** Pointer to scatter plot plugin */
     ColorAction         _backgroundColorAction;     /** Color action for setting the background color action */
+    ToggleAction        _randomizedDepthAction;     /** whether the z-order of each point is to be randomized or not */
 
     static const QColor DEFAULT_BACKGROUND_COLOR;
 

--- a/src/ScatterplotWidget.cpp
+++ b/src/ScatterplotWidget.cpp
@@ -682,6 +682,18 @@ void ScatterplotWidget::setSelectionOutlineHaloEnabled(bool selectionOutlineHalo
     update();
 }
 
+void ScatterplotWidget::setRandomizedDepthEnabled(bool randomizedDepth)
+{
+    _pointRenderer.setRandomizedDepthEnabled(randomizedDepth);
+
+    update();
+}
+
+bool ScatterplotWidget::getRandomizedDepthEnabled() const
+{
+    return _pointRenderer.getRandomizedDepthEnabled();
+}
+
 void ScatterplotWidget::initializeGL()
 {
     initializeOpenGLFunctions();
@@ -757,6 +769,10 @@ void ScatterplotWidget::paintGL()
 
             // Reset the blending function
             glEnable(GL_BLEND);
+
+            if (getRandomizedDepthEnabled())
+                glEnable(GL_DEPTH_TEST);
+
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
                
             switch (_renderMode)

--- a/src/ScatterplotWidget.h
+++ b/src/ScatterplotWidget.h
@@ -211,9 +211,21 @@ public: // Selection
 
     /**
      * Set whether the selection outline halo is enabled or not
-     * @param selectionOutlineHaloEnabled Boolean determining whether the selection outline halo is enabled or not
+     * @param randomizedDepth Boolean determining whether the selection outline halo is enabled or not
+     */
+    void setRandomizedDepthEnabled(bool randomizedDepth);
+
+    /**
+     * Set whether the z-order of each point is to be randomized or not
+     * @param selectionOutlineHaloEnabled Boolean determining whether the z-order of each point is to be randomized or not
      */
     void setSelectionOutlineHaloEnabled(bool selectionOutlineHaloEnabled);
+
+    /**
+     * Get whether the z-order of each point is to be randomized or not
+     * @return Boolean determining whether the z-order of each point is to be randomized or not
+     */
+    bool getRandomizedDepthEnabled() const;
 
 protected:
     void initializeGL()         Q_DECL_OVERRIDE;


### PR DESCRIPTION
- [x] Adds the option to randomize the z-order of points
- [x] Toggled in the settings popup

Works in concert with [this](https://github.com/ManiVaultStudio/core/tree/feature/point_renderer_randomized_z_ordering) branch