### PR TITLE
Always disable pixel selection during navigation

### DIFF
--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -334,7 +334,7 @@ void ScatterplotPlugin::selectPoints()
     auto& pixelSelectionTool = _scatterPlotWidget->getPixelSelectionTool();
 
     // Only proceed with a valid points position dataset and when the pixel selection tool is active
-    if (!_positionDataset.isValid() || !pixelSelectionTool.isActive() || _scatterPlotWidget->isNavigating())
+    if (!_positionDataset.isValid() || !pixelSelectionTool.isActive() || _scatterPlotWidget->isNavigating() || !pixelSelectionTool.isEnabled())
         return;
 
     auto selectionAreaImage = pixelSelectionTool.getAreaPixmap().toImage();
@@ -424,12 +424,10 @@ void ScatterplotPlugin::samplePoints()
 {
     auto& samplerPixelSelectionTool = _scatterPlotWidget->getSamplerPixelSelectionTool();
 
-    if (!_positionDataset.isValid() || _scatterPlotWidget->isNavigating())
+    if (!_positionDataset.isValid() || !samplerPixelSelectionTool.isActive() || _scatterPlotWidget->isNavigating() || !samplerPixelSelectionTool.isEnabled())
         return;
 
     auto selectionAreaImage = samplerPixelSelectionTool.getAreaPixmap().toImage();
-
-    auto selectionSet = _positionDataset->getSelection<Points>();
 
     std::vector<std::uint32_t> targetSelectionIndices;
 

--- a/src/ScatterplotPlugin.h
+++ b/src/ScatterplotPlugin.h
@@ -110,7 +110,7 @@ public: // Serialization
 
 private:
     mv::gui::DropWidget*            _dropWidget;                /** Widget for dropping datasets */
-    ScatterplotWidget*              _scatterPlotWidget;         /** THe visualization widget */
+    ScatterplotWidget*              _scatterPlotWidget;         /** The visualization widget */
 
     Dataset<Points>                 _positionDataset;           /** Smart pointer to points dataset for point position */
     Dataset<Points>                 _positionSourceDataset;     /** Smart pointer to source of the points dataset for point position (if any) */

--- a/src/ScatterplotWidget.cpp
+++ b/src/ScatterplotWidget.cpp
@@ -156,15 +156,27 @@ bool ScatterplotWidget::event(QEvent* event)
     if (event->type() == QEvent::KeyRelease)
     {
         if (const auto* keyEvent = static_cast<QKeyEvent*>(event))
+        {
             if (keyEvent->key() == Qt::Key_Alt)
+            {
                 _isNavigating = false;
+                _pixelSelectionTool.setEnabled(true);
+                _samplerPixelSelectionTool.setEnabled(true);
+            }
+        }
 
     }
     else if (event->type() == QEvent::KeyPress)
     {
         if (const auto* keyEvent = static_cast<QKeyEvent*>(event))
+        {
             if (keyEvent->key() == Qt::Key_Alt)
+            {
                 _isNavigating = true;
+                _pixelSelectionTool.setEnabled(false);
+                _samplerPixelSelectionTool.setEnabled(false);
+            }
+        }
 
     }
 
@@ -192,7 +204,6 @@ bool ScatterplotWidget::event(QEvent* event)
                     // Navigation
                     if (mouseEvent->buttons() == Qt::LeftButton)
                     {
-                        _pixelSelectionTool.setEnabled(false);
                         setCursor(Qt::ClosedHandCursor);
                         _mousePositions << mouseEvent->pos();
                         update();
@@ -204,7 +215,6 @@ bool ScatterplotWidget::event(QEvent* event)
 
             case QEvent::MouseButtonRelease:
             {
-                _pixelSelectionTool.setEnabled(true);
                 setCursor(Qt::ArrowCursor);
                 _mousePositions.clear();
                 update();

--- a/src/ScatterplotWidget.h
+++ b/src/ScatterplotWidget.h
@@ -17,10 +17,13 @@
 #include <QOpenGLWidget>
 #include <QPoint>
 
-class ScatterplotPlugin;
-
 using namespace mv::gui;
 using namespace mv::util;
+
+namespace mv::plugin
+{
+    class ViewPlugin;
+}
 
 struct widgetSizeInfo {
     float width;
@@ -49,7 +52,7 @@ public:
     };
 
 public:
-    ScatterplotWidget();
+    ScatterplotWidget(mv::plugin::ViewPlugin* parentPlugin = nullptr);
 
     ~ScatterplotWidget();
 
@@ -322,6 +325,8 @@ private:
     QVector<QPoint>             _mousePositions;                /** Recorded mouse positions */
     bool                        _isNavigating;                  /** Boolean determining whether view navigation is currently taking place or not */
     bool                        _weightDensity;                 /** Use point scalar sizes to weight density */
+
+    mv::plugin::ViewPlugin*     _parentPlugin = nullptr;
 
     friend class NavigationAction;
 };


### PR DESCRIPTION
This fixes a rare issue where the pixel selection tool is shown during navigation (even though no selection is taking place).