### PR TITLE
Fix color mapping

### DIFF
--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -603,8 +603,10 @@ void ScatterplotPlugin::loadColors(const Dataset<Clusters>& clusters)
     {
         for (size_t i = 0; i < static_cast<size_t>(clusterVec.size()); i++)
         {
-            const auto color = clusterVec[i].getColor();
-            localColors[i] = Vector3f(color.redF(), color.greenF(), color.blueF());
+            const auto& cluster = clusterVec[i];
+            const auto color    = cluster.getColor();
+
+            localColors[cluster.getIndices()[0]] = Vector3f(color.redF(), color.greenF(), color.blueF());
         }
 
     }


### PR DESCRIPTION
`void ScatterplotPlugin::loadColors(const Dataset<Clusters>& clusters)` assumes that the cluster index automatically maps to the point index, which generally is not the case. The `localColors` variable is now populated by using the first index of each cluster.