### PR TITLE
Set View instead of Viewer PluginType

### DIFF
--- a/PluginInfo.json
+++ b/PluginInfo.json
@@ -4,6 +4,6 @@
         "plugin" : "1.0.0",
         "core" : ["1.3"]
     },
-    "type" : "Viewer",
+    "type" : "View",
     "dependencies" : ["Points"]
 }


### PR DESCRIPTION
The `type` is currently mainly used for organizing plugins in `FOLDER`s for IDEs that support it (Visual Studio)