### PR TITLE
Recolor with HSNE embedding

### DIFF
--- a/src/ColoringAction.cpp
+++ b/src/ColoringAction.cpp
@@ -179,6 +179,9 @@ Dataset<DatasetImpl> ColoringAction::getCurrentColorDataset() const
 
 void ColoringAction::setCurrentColorDataset(const Dataset<DatasetImpl>& colorDataset)
 {
+    if (!colorDataset.isValid())
+        return;
+
     addColorDataset(colorDataset);
 
     const auto colorDatasetRowIndex = _colorByModel.rowIndex(colorDataset);

--- a/src/PointPlotAction.cpp
+++ b/src/PointPlotAction.cpp
@@ -210,6 +210,24 @@ void PointPlotAction::addPointOpacityDataset(const Dataset<DatasetImpl>& pointOp
     _opacityAction.addDataset(pointOpacityDataset);
 }
 
+void PointPlotAction::setCurrentPointSizeDataset(const Dataset<DatasetImpl>& pointSizeDataset)
+{
+    if (!pointSizeDataset.isValid())
+        return;
+
+    addPointSizeDataset(pointSizeDataset);
+    _sizeAction.setCurrentDataset(pointSizeDataset);
+}
+
+void PointPlotAction::setCurrentPointOpacityDataset(const Dataset<DatasetImpl>& pointOpacityDataset)
+{
+    if (!pointOpacityDataset.isValid())
+        return;
+
+    addPointOpacityDataset(pointOpacityDataset);
+    _opacityAction.setCurrentDataset(pointOpacityDataset);
+}
+
 void PointPlotAction::updateDefaultDatasets()
 {
     if (_scatterplotPlugin == nullptr)

--- a/src/PointPlotAction.h
+++ b/src/PointPlotAction.h
@@ -58,6 +58,18 @@ public:
      */
     void addPointOpacityDataset(const Dataset<DatasetImpl>& pointOpacityDataset);
 
+    /**
+     * Set the current point size dataset
+     * @param pointSizeDataset Smart pointer to point size dataset
+     */
+    void setCurrentPointSizeDataset(const Dataset<DatasetImpl>& pointSizeDataset);
+
+    /**
+     * Set the current opacity size dataset
+     * @param pointOpacityDataset Smart pointer to opacity size dataset
+     */
+    void setCurrentPointOpacityDataset(const Dataset<DatasetImpl>& pointOpacityDataset);
+
 protected:
 
     /** Update default datasets (candidates are children of points type and with matching number of points) */

--- a/src/ScalarAction.cpp
+++ b/src/ScalarAction.cpp
@@ -38,6 +38,9 @@ void ScalarAction::addDataset(const Dataset<DatasetImpl>& dataset)
 {
     auto& sourceModel = _sourceAction.getModel();
 
+    if (sourceModel.hasDataset(dataset))
+        return;
+
     sourceModel.addDataset(dataset);
 
     connect(&sourceModel.getDatasets().last(), &Dataset<DatasetImpl>::dataChanged, this, [this, dataset]() {

--- a/src/ScalarSourceModel.cpp
+++ b/src/ScalarSourceModel.cpp
@@ -74,6 +74,8 @@ QVariant ScalarSourceModel::data(const QModelIndex& index, int role) const
                 if (row == DefaultRow::Selection)
                     return "Selection";
             }
+
+            break;
         }
 
         default:
@@ -86,7 +88,7 @@ QVariant ScalarSourceModel::data(const QModelIndex& index, int role) const
 void ScalarSourceModel::addDataset(const Dataset<DatasetImpl>& dataset)
 {
     // Avoid duplicates
-    if (rowIndex(dataset) >= DefaultRow::DatasetStart)
+    if (hasDataset(dataset))
         return;
 
     // Insert row into model
@@ -125,6 +127,11 @@ void ScalarSourceModel::addDataset(const Dataset<DatasetImpl>& dataset)
         // Notify others that the data changed
         emit dataChanged(modelIndex, modelIndex);
     });
+}
+
+bool ScalarSourceModel::hasDataset(const Dataset<DatasetImpl>& dataset) const
+{
+    return rowIndex(dataset) >= DefaultRow::DatasetStart;
 }
 
 void ScalarSourceModel::removeDataset(const Dataset<DatasetImpl>& dataset)

--- a/src/ScalarSourceModel.h
+++ b/src/ScalarSourceModel.h
@@ -66,6 +66,13 @@ public:
     void addDataset(const Dataset<DatasetImpl>& dataset);
 
     /**
+     * Determines whether a given dataset is already loaded
+     * @param dataset Smart pointer to dataset
+     * @return whether the dataset is already loaded
+     */
+    bool hasDataset(const Dataset<DatasetImpl>& dataset) const;
+
+    /**
      * Remove a dataset
      * @param dataset Smart pointer to dataset
      */

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -183,12 +183,14 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
                     /*else*/ false;
 
                 if (sameNumPoints || sameNumPointsAsFull) {
-
                     // Offer the option to use the points dataset as source for points colors
                     dropRegions << new DropWidget::DropRegion(this, "Point color", QString("Colorize %1 points with %2").arg(_positionDataset->text(), candidateDataset->text()), "palette", true, [this, candidateDataset]() {
                         _settingsAction.getColoringAction().setCurrentColorDataset(candidateDataset);   // calls addColorDataset internally
                         });
 
+                }
+
+                if (sameNumPoints) {
                     // Offer the option to use the points dataset as source for points size
                     dropRegions << new DropWidget::DropRegion(this, "Point size", QString("Size %1 points with %2").arg(_positionDataset->text(), candidateDataset->text()), "ruler-horizontal", true, [this, candidateDataset]() {
                         _settingsAction.getPlotAction().getPointPlotAction().setCurrentPointSizeDataset(candidateDataset);

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -184,22 +184,19 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
 
                 if (sameNumPoints || sameNumPointsAsFull) {
 
-                    // The number of points is equal, so offer the option to use the points dataset as source for points colors
+                    // Offer the option to use the points dataset as source for points colors
                     dropRegions << new DropWidget::DropRegion(this, "Point color", QString("Colorize %1 points with %2").arg(_positionDataset->text(), candidateDataset->text()), "palette", true, [this, candidateDataset]() {
-                        _settingsAction.getColoringAction().addColorDataset(candidateDataset);
-                        _settingsAction.getColoringAction().setCurrentColorDataset(candidateDataset);
+                        _settingsAction.getColoringAction().setCurrentColorDataset(candidateDataset);   // calls addColorDataset internally
                         });
 
-                    // The number of points is equal, so offer the option to use the points dataset as source for points size
+                    // Offer the option to use the points dataset as source for points size
                     dropRegions << new DropWidget::DropRegion(this, "Point size", QString("Size %1 points with %2").arg(_positionDataset->text(), candidateDataset->text()), "ruler-horizontal", true, [this, candidateDataset]() {
-                        _settingsAction.getPlotAction().getPointPlotAction().addPointSizeDataset(candidateDataset);
-                        _settingsAction.getPlotAction().getPointPlotAction().getSizeAction().setCurrentDataset(candidateDataset);
+                        _settingsAction.getPlotAction().getPointPlotAction().setCurrentPointSizeDataset(candidateDataset);
                         });
 
-                    // The number of points is equal, so offer the option to use the points dataset as source for points opacity
+                    // Offer the option to use the points dataset as source for points opacity
                     dropRegions << new DropWidget::DropRegion(this, "Point opacity", QString("Set %1 points opacity with %2").arg(_positionDataset->text(), candidateDataset->text()), "brush", true, [this, candidateDataset]() {
-                        _settingsAction.getPlotAction().getPointPlotAction().addPointOpacityDataset(candidateDataset);
-                        _settingsAction.getPlotAction().getPointPlotAction().getOpacityAction().setCurrentDataset(candidateDataset);
+                        _settingsAction.getPlotAction().getPointPlotAction().setCurrentPointOpacityDataset(candidateDataset);
                         });
                 }
             }

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -579,9 +579,9 @@ void ScatterplotPlugin::samplePoints()
         if (getSamplerAction().getRestrictNumberOfElementsAction().isChecked() && numberOfPoints >= getSamplerAction().getMaximumNumberOfElementsAction().getValue())
             break;
 
-        const auto& distance = sampledPoint.first;
-        const auto& localPointIndex = sampledPoint.second;
-        const auto& globalPointIndex = localGlobalIndices[localPointIndex];
+        const auto& distance            = sampledPoint.first;
+        const auto& localPointIndex     = sampledPoint.second;
+        const auto& globalPointIndex    = localGlobalIndices[localPointIndex];
 
         distances << distance;
         localPointIndices << localPointIndex;


### PR DESCRIPTION
It is already possible to recolor HSNE embeddings based on Cluster data derived from the original data, see `ScatterplotPlugin::loadColors(const Dataset<Clusters>& clusters)`. This PR uses the same mapping from local to global indices to also allow recoloring HSNE embeddings basd on other point data.

Also, fixes #117: 
- Don't call `ColoringAction::addColorDataset` double
- Setting the point color, size and opacity now follow the same syntax
- Added checks if point size and opacity datasets are already in the respective models