### PR TITLE
Color by selection mapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ find_package(ManiVault COMPONENTS Core PointData ClusterData ColorData ImageData
 set(PLUGIN
     src/ScatterplotPlugin.h
     src/ScatterplotPlugin.cpp
+    src/MappingUtils.h
+    src/MappingUtils.cpp
 )
 
 set(UI

--- a/src/MappingUtils.cpp
+++ b/src/MappingUtils.cpp
@@ -16,15 +16,6 @@
 
 using CheckFunc = std::function<bool(const mv::LinkedData& linkedData, const mv::Dataset<Points>& target)>;
 
-static void printLinkedDataNames(const mv::Dataset<Points>& data) {
-    const std::vector<mv::LinkedData>& linkedFromColors = data->getLinkedData();
-    if (!linkedFromColors.empty()) {
-        qDebug() << data->getGuiName();
-        qDebug() << linkedFromColors[0].getSourceDataSet()->getGuiName();
-        qDebug() << linkedFromColors[0].getTargetDataset()->getGuiName();
-    }
-}
-
 std::pair<const mv::LinkedData*, unsigned int> getSelectionMapping(const mv::Dataset<Points>& source, const mv::Dataset<Points>& target, CheckFunc checkMapping) {
     const std::vector<mv::LinkedData>& linkedDatas = source->getLinkedData();
 
@@ -103,9 +94,6 @@ bool checkSurjectiveMapping(const mv::LinkedData& linkedData, const std::uint32_
 }
 
 bool checkSelectionMapping(const mv::Dataset<Points>& colors, const mv::Dataset<Points>& positions) {
-
-    printLinkedDataNames(colors);
-    printLinkedDataNames(positions);
 
     // Check if there is a mapping
     auto [mapping, numTargetPoints] = getSelectionMappingColorsToPositions(colors, positions);

--- a/src/MappingUtils.cpp
+++ b/src/MappingUtils.cpp
@@ -14,9 +14,7 @@
 #include <utility>
 #include <vector>
 
-using CheckFunc = std::function<bool(const mv::LinkedData& linkedData, const mv::Dataset<Points>& target)>;
-
-std::pair<const mv::LinkedData*, unsigned int> getSelectionMapping(const mv::Dataset<Points>& source, const mv::Dataset<Points>& target, CheckFunc checkMapping) {
+std::pair<const mv::LinkedData*, unsigned int> getSelectionMapping(const mv::Dataset<Points>& source, const mv::Dataset<Points>& target, LinkedDataCondition checkMapping) {
     const std::vector<mv::LinkedData>& linkedDatas = source->getLinkedData();
 
     if (linkedDatas.empty())

--- a/src/MappingUtils.cpp
+++ b/src/MappingUtils.cpp
@@ -1,0 +1,110 @@
+#include "MappingUtils.h"
+
+#include <Dataset.h>
+#include <LinkedData.h>
+#include <PointData/PointData.h>
+#include <Set.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <optional>
+#include <ranges>
+#include <vector>
+
+bool parentHasSameNumPoints(const mv::Dataset<mv::DatasetImpl> data, const mv::Dataset<Points>& other) {
+    if (data->isDerivedData()) {
+        const auto parent = data->getParent();
+        if (parent->getDataType() == PointType) {
+            const auto parentPoints = mv::Dataset<Points>(parent);
+            return parentPoints->getNumPoints() == other->getNumPoints();
+        }
+    }
+    return false;
+}
+
+using CheckFunc = std::function<bool(const mv::LinkedData& linkedData, const mv::Dataset<Points>& target)>;
+
+std::optional<const mv::LinkedData*> getSelectionMapping(const mv::Dataset<Points>& source, const mv::Dataset<Points>& target, CheckFunc checkMapping) {
+    const std::vector<mv::LinkedData>& linkedDatas = source->getLinkedData();
+
+    if (linkedDatas.empty())
+        return std::nullopt;
+
+    // find linked data between source and target OR source and target's parent, if target is derived and they have the same number of points
+    const auto it = std::ranges::find_if(linkedDatas, [&target, &checkMapping](const mv::LinkedData& linkedData) -> bool {
+        return checkMapping(linkedData, target);
+        });
+
+    if (it != linkedDatas.end()) {
+        return &(*it);  // return pointer to the found object
+    }
+
+    return std::nullopt; // nothing found
+}
+
+std::optional<const mv::LinkedData*> getSelectionMappingColorsToPositions(const mv::Dataset<Points>& colors, const mv::Dataset<Points>& positions) {
+    auto testTargetAndParent = [](const mv::LinkedData& linkedData, const mv::Dataset<Points>& positions) -> bool {
+        const mv::Dataset<mv::DatasetImpl> mapTargetData = linkedData.getTargetDataset();
+        return mapTargetData == positions || parentHasSameNumPoints(mapTargetData, positions);
+        };
+
+    return getSelectionMapping(colors, positions, testTargetAndParent);
+}
+
+std::optional<const mv::LinkedData*> getSelectionMappingPositionsToColors(const mv::Dataset<Points>& positions, const mv::Dataset<Points>& colors) {
+    auto testTarget = [](const mv::LinkedData& linkedData, const mv::Dataset<Points>& colors) -> bool {
+        return linkedData.getTargetDataset() == colors;
+        };
+
+    auto mapping = getSelectionMapping(positions, colors, testTarget);
+
+    if (!mapping.has_value() && parentHasSameNumPoints(positions, positions)) {
+        const auto positionsParent = positions->getParent<Points>();
+        mapping = getSelectionMapping(positionsParent, colors, testTarget);
+    }
+
+    return mapping;
+}
+
+bool checkSurjectiveMapping(const mv::LinkedData& linkedData, const std::uint32_t numPointsInTarget) {
+    const std::map<std::uint32_t, std::vector<std::uint32_t>>& linkedMap = linkedData.getMapping().getMap();
+
+    std::vector<bool> found(numPointsInTarget, false);
+    std::uint32_t count = 0;
+
+    for (const auto& [key, vec] : linkedMap) {
+        for (std::uint32_t val : vec) {
+            if (val >= numPointsInTarget) continue; // Skip values that are too large
+
+            if (!found[val]) {
+                found[val] = true;
+                if (++count == numPointsInTarget)
+                    return true;
+            }
+        }
+    }
+
+    return false; // The previous loop would have returned early if the entire taget set was covered
+}
+
+bool checkSelectionMapping(const mv::Dataset<Points>& colors, const mv::Dataset<Points>& positions) {
+
+    // Check if there is a mapping
+    auto mapping = getSelectionMappingColorsToPositions(colors, positions);
+    auto numTargetPoints = positions->getNumPoints();
+
+    if (!mapping.has_value() || mapping.value() == nullptr) {
+
+        mapping = getSelectionMappingPositionsToColors(positions, colors);
+        numTargetPoints = colors->getNumPoints();
+
+        if (!mapping.has_value() || mapping.value() == nullptr)
+            return false;
+    }
+
+    const bool mappingCoversData = checkSurjectiveMapping(*(mapping.value()), numTargetPoints);
+
+    return mappingCoversData;
+}

--- a/src/MappingUtils.cpp
+++ b/src/MappingUtils.cpp
@@ -107,5 +107,5 @@ bool checkSelectionMapping(const mv::Dataset<Points>& colors, const mv::Dataset<
     if (!mapping)
         return false;
 
-    return checkSurjectiveMapping(*mapping, numTargetPoints);
+    return true;
 }

--- a/src/MappingUtils.cpp
+++ b/src/MappingUtils.cpp
@@ -13,15 +13,15 @@
 #include <ranges>
 #include <vector>
 
-bool parentHasSameNumPoints(const mv::Dataset<mv::DatasetImpl> data, const mv::Dataset<Points>& other) {
-    if (data->isDerivedData()) {
-        const auto parent = data->getParent();
-        if (parent->getDataType() == PointType) {
-            const auto parentPoints = mv::Dataset<Points>(parent);
-            return parentPoints->getNumPoints() == other->getNumPoints();
-        }
+using CheckFunc = std::function<bool(const mv::LinkedData& linkedData, const mv::Dataset<Points>& target)>;
+
+static void printLinkedDataNames(const mv::Dataset<Points>& data) {
+    const std::vector<mv::LinkedData>& linkedFromColors = data->getLinkedData();
+    if (!linkedFromColors.empty()) {
+        qDebug() << data->getGuiName();
+        qDebug() << linkedFromColors[0].getSourceDataSet()->getGuiName();
+        qDebug() << linkedFromColors[0].getTargetDataset()->getGuiName();
     }
-    return false;
 }
 
 using CheckFunc = std::function<bool(const mv::LinkedData& linkedData, const mv::Dataset<Points>& target)>;

--- a/src/MappingUtils.cpp
+++ b/src/MappingUtils.cpp
@@ -68,6 +68,17 @@ std::pair<const mv::LinkedData*, unsigned int> getSelectionMappingPositionsToCol
 
     return { mapping, numTargetPoints };
 }
+
+std::pair<const mv::LinkedData*, unsigned int> getSelectionMappingPositionSourceToColors(const mv::Dataset<Points>& positions, const mv::Dataset<Points>& colors) {
+    if (!positions->isDerivedData())
+        return { nullptr, 0 };
+
+    const auto fullSourceData = positions->getSourceDataset<Points>()->getFullDataset<Points>();
+
+    if(!fullSourceData.isValid())
+        return { nullptr, 0 };
+
+    return getSelectionMappingPositionsToColors(fullSourceData, colors);
 }
 
 bool checkSurjectiveMapping(const mv::LinkedData& linkedData, const std::uint32_t numPointsInTarget) {
@@ -93,9 +104,8 @@ bool checkSurjectiveMapping(const mv::LinkedData& linkedData, const std::uint32_
 
 bool checkSelectionMapping(const mv::Dataset<Points>& colors, const mv::Dataset<Points>& positions) {
 
-    // Check if there is a mapping
-    auto mapping = getSelectionMappingColorsToPositions(colors, positions);
-    auto numTargetPoints = positions->getNumPoints();
+    printLinkedDataNames(colors);
+    printLinkedDataNames(positions);
 
     // Check if there is a mapping
     auto [mapping, numTargetPoints] = getSelectionMappingColorsToPositions(colors, positions);
@@ -103,6 +113,8 @@ bool checkSelectionMapping(const mv::Dataset<Points>& colors, const mv::Dataset<
     if (!mapping)
         std::tie(mapping, numTargetPoints) = getSelectionMappingPositionsToColors(positions, colors);
 
+    if (!mapping)
+        std::tie(mapping, numTargetPoints) = getSelectionMappingPositionSourceToColors(positions, colors);
 
     if (!mapping)
         return false;

--- a/src/MappingUtils.h
+++ b/src/MappingUtils.h
@@ -7,7 +7,7 @@
 
 #include <cstdint>
 #include <functional>
-#include <optional>
+#include <utility>
 
 // This only checks the immedeate parent and is deliberately not recursive
 // We might consider the latter in the future, but might need to cover edge cases
@@ -33,11 +33,11 @@ inline bool fullSourceHasSameNumPoints(const mv::Dataset<mv::DatasetImpl> data, 
 
 using CheckFunc = std::function<bool(const mv::LinkedData& linkedData, const mv::Dataset<Points>& target)>;
 
-std::optional<const mv::LinkedData*> getSelectionMapping(const mv::Dataset<Points>& source, const mv::Dataset<Points>& target, CheckFunc checkMapping);
+std::pair<const mv::LinkedData*, unsigned int> getSelectionMapping(const mv::Dataset<Points>& source, const mv::Dataset<Points>& target, CheckFunc checkMapping);
 
-std::optional<const mv::LinkedData*> getSelectionMappingColorsToPositions(const mv::Dataset<Points>& colors, const mv::Dataset<Points>& positions);
+std::pair<const mv::LinkedData*, unsigned int> getSelectionMappingColorsToPositions(const mv::Dataset<Points>& colors, const mv::Dataset<Points>& positions);
 
-std::optional<const mv::LinkedData*> getSelectionMappingPositionsToColors(const mv::Dataset<Points>& positions, const mv::Dataset<Points>& colors);
+std::pair<const mv::LinkedData*, unsigned int> getSelectionMappingPositionsToColors(const mv::Dataset<Points>& positions, const mv::Dataset<Points>& colors);
 
 // Check if the mapping is surjective, i.e. hits all elements in the target
 bool checkSurjectiveMapping(const mv::LinkedData& linkedData, const std::uint32_t numPointsInTarget);

--- a/src/MappingUtils.h
+++ b/src/MappingUtils.h
@@ -39,6 +39,8 @@ std::pair<const mv::LinkedData*, unsigned int> getSelectionMappingColorsToPositi
 
 std::pair<const mv::LinkedData*, unsigned int> getSelectionMappingPositionsToColors(const mv::Dataset<Points>& positions, const mv::Dataset<Points>& colors);
 
+std::pair<const mv::LinkedData*, unsigned int> getSelectionMappingPositionSourceToColors(const mv::Dataset<Points>& positions, const mv::Dataset<Points>& colors);
+
 // Check if the mapping is surjective, i.e. hits all elements in the target
 bool checkSurjectiveMapping(const mv::LinkedData& linkedData, const std::uint32_t numPointsInTarget);
 

--- a/src/MappingUtils.h
+++ b/src/MappingUtils.h
@@ -31,14 +31,24 @@ inline bool fullSourceHasSameNumPoints(const mv::Dataset<mv::DatasetImpl> data, 
     return data->getSourceDataset<Points>()->getFullDataset<Points>()->getNumPoints() == other->getNumPoints();
 }
 
-using CheckFunc = std::function<bool(const mv::LinkedData& linkedData, const mv::Dataset<Points>& target)>;
+using LinkedDataCondition = std::function<bool(const mv::LinkedData& linkedData, const mv::Dataset<Points>& target)>;
 
-std::pair<const mv::LinkedData*, unsigned int> getSelectionMapping(const mv::Dataset<Points>& source, const mv::Dataset<Points>& target, CheckFunc checkMapping);
+/*  Returns a mapping (linked data) from source that fulfils a given condition based on target, e.g.
+    auto checkMapping = [](const mv::LinkedData& linkedData, const mv::Dataset<Points>& target) -> bool {
+        return linkedData.getTargetDataset() == target;
+        };
+    This function will return the first match of the condition
+*/
+std::pair<const mv::LinkedData*, unsigned int> getSelectionMapping(const mv::Dataset<Points>& source, const mv::Dataset<Points>& target, LinkedDataCondition checkMapping);
 
+// Returns a mapping (linked data) from colors whose target is positions or whose target's parent has the same number of points as positions
 std::pair<const mv::LinkedData*, unsigned int> getSelectionMappingColorsToPositions(const mv::Dataset<Points>& colors, const mv::Dataset<Points>& positions);
 
+// Returns a mapping (linked data) from positions whose target is colors or 
+//  a mapping from positions' parent whose target is colors if the number of data points match 
 std::pair<const mv::LinkedData*, unsigned int> getSelectionMappingPositionsToColors(const mv::Dataset<Points>& positions, const mv::Dataset<Points>& colors);
 
+// Returns a mapping (linked data) from positions' source data whose target is colors 
 std::pair<const mv::LinkedData*, unsigned int> getSelectionMappingPositionSourceToColors(const mv::Dataset<Points>& positions, const mv::Dataset<Points>& colors);
 
 // Check if the mapping is surjective, i.e. hits all elements in the target

--- a/src/MappingUtils.h
+++ b/src/MappingUtils.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <Dataset.h>
+#include <LinkedData.h>
+#include <PointData/PointData.h>
+#include <Set.h>
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+
+// This only checks the immedeate parent and is deliberately not recursive
+// We might consider the latter in the future, but might need to cover edge cases
+bool parentHasSameNumPoints(const mv::Dataset<mv::DatasetImpl> data, const mv::Dataset<Points>& other);
+
+using CheckFunc = std::function<bool(const mv::LinkedData& linkedData, const mv::Dataset<Points>& target)>;
+
+std::optional<const mv::LinkedData*> getSelectionMapping(const mv::Dataset<Points>& source, const mv::Dataset<Points>& target, CheckFunc checkMapping);
+
+std::optional<const mv::LinkedData*> getSelectionMappingColorsToPositions(const mv::Dataset<Points>& colors, const mv::Dataset<Points>& positions);
+
+std::optional<const mv::LinkedData*> getSelectionMappingPositionsToColors(const mv::Dataset<Points>& positions, const mv::Dataset<Points>& colors);
+
+// Check if the mapping is surjective, i.e. hits all elements in the target
+bool checkSurjectiveMapping(const mv::LinkedData& linkedData, const std::uint32_t numPointsInTarget);
+
+// returns whether there is a selection map from colors to positions or positions to colors (or respective parents)
+// checks whether the mapping covers all elements in the target
+bool checkSelectionMapping(const mv::Dataset<Points>& colors, const mv::Dataset<Points>& positions);

--- a/src/MappingUtils.h
+++ b/src/MappingUtils.h
@@ -11,7 +11,25 @@
 
 // This only checks the immedeate parent and is deliberately not recursive
 // We might consider the latter in the future, but might need to cover edge cases
-bool parentHasSameNumPoints(const mv::Dataset<mv::DatasetImpl> data, const mv::Dataset<Points>& other);
+inline bool parentHasSameNumPoints(const mv::Dataset<mv::DatasetImpl> data, const mv::Dataset<Points>& other) {
+    if (!data->isDerivedData())
+        return false;
+
+    const auto parent = data->getParent();
+    if (parent->getDataType() != PointType)
+        return false;
+
+    const auto parentPoints = mv::Dataset<Points>(parent);
+    return parentPoints->getNumPoints() == other->getNumPoints();
+}
+
+// Is the data derived and does it's full source data have same number of points as the other data
+inline bool fullSourceHasSameNumPoints(const mv::Dataset<mv::DatasetImpl> data, const mv::Dataset<Points>& other) {
+    if (!data->isDerivedData())
+        return false;
+
+    return data->getSourceDataset<Points>()->getFullDataset<Points>()->getNumPoints() == other->getNumPoints();
+}
 
 using CheckFunc = std::function<bool(const mv::LinkedData& linkedData, const mv::Dataset<Points>& target)>;
 

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -189,10 +189,7 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
                 const bool hasSameNumPoints     = numPointsPosition == numPointsCandidate;
 
                 // [2. Derived from a parent]
-                const bool hasSameNumPointsAsFull = 
-                    /*if*/   _positionDataset->isDerivedData() ?
-                    /*then*/ _positionDataset->getSourceDataset<Points>()->getFullDataset<Points>()->getNumPoints() == numPointsCandidate :
-                    /*else*/ false;
+                const bool hasSameNumPointsAsFull = fullSourceHasSameNumPoints(_positionDataset, candidateDataset);
 
                 // [3. Full selection mapping]
                 const bool hasSelectionMapping  = checkSelectionMapping(candidateDataset, _positionDataset);
@@ -681,10 +678,7 @@ void ScatterplotPlugin::loadColors(const Dataset<Points>& pointsColor, const std
     if (numColorPoints != _numPoints) {
 
         try {
-            const bool hasSameNumPointsAsFull =
-                /*if*/   _positionDataset->isDerivedData() ?
-                /*then*/ _positionSourceDataset->getFullDataset<Points>()->getNumPoints() == numColorPoints :
-                /*else*/ false;
+            const bool hasSameNumPointsAsFull = fullSourceHasSameNumPoints(_positionDataset, pointsColor);
 
             if (hasSameNumPointsAsFull) {
                 std::vector<std::uint32_t> globalIndices;

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -691,7 +691,10 @@ void ScatterplotPlugin::loadColors(const Dataset<Points>& pointsColor, const std
             }
             else if ( // mapping from color data set to position data set
                 const auto [selectionMapping, numPointsTarget] = getSelectionMappingColorsToPositions(pointsColor, _positionDataset);
-                /* check if valid */ selectionMapping != nullptr && numPointsTarget == _numPoints
+                /* check if valid */ 
+                selectionMapping != nullptr && 
+                numPointsTarget == _numPoints &&
+                checkSurjectiveMapping(*selectionMapping, numPointsTarget)
                 )
             {
                 // Map values like selection
@@ -706,10 +709,12 @@ void ScatterplotPlugin::loadColors(const Dataset<Points>& pointsColor, const std
             }
             else if ( // mapping from position data set to color data set 
                 const auto [selectionMapping, numPointsTarget] = getSelectionMappingPositionsToColors(_positionDataset, pointsColor);
-                /* check if valid */ selectionMapping != nullptr && numPointsTarget == numColorPoints
+                /* check if valid */ 
+                selectionMapping != nullptr &&
+                numPointsTarget == numColorPoints &&
+                checkSurjectiveMapping(*selectionMapping, numPointsTarget)
                 )
             {
-                
                 // Map values like selection (in reverse, use first value that occurs)
                 const mv::SelectionMap::Map& mapPositionsToColors = selectionMapping->getMapping().getMap();
 
@@ -724,7 +729,10 @@ void ScatterplotPlugin::loadColors(const Dataset<Points>& pointsColor, const std
             }
             else if ( // mapping from source of position data set to color data set 
                 const auto [selectionMapping, numPointsTarget] = getSelectionMappingPositionSourceToColors(_positionDataset, pointsColor);
-                /* check if valid */ selectionMapping != nullptr && numPointsTarget == numColorPoints
+                /* check if valid */ 
+                selectionMapping != nullptr && 
+                numPointsTarget == numColorPoints &&
+                checkSurjectiveMapping(*selectionMapping, numPointsTarget)
                 )
             {
                 // the selection map is from full source data of positions data to pointsColor

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -743,8 +743,6 @@ void ScatterplotPlugin::loadColors(const Dataset<Points>& pointsColor, const std
             /*then*/ _positionSourceDataset->getFullDataset<Points>()->getNumPoints() == numColorPoints :
             /*else*/ false;
 
-        const auto validSelectionMapping = getSelectionMapping(pointsColor, _positionDataset);
-
         if (hasSameNumPointsAsFull) {
             std::vector<std::uint32_t> globalIndices;
             _positionDataset->getGlobalIndices(globalIndices);
@@ -756,12 +754,16 @@ void ScatterplotPlugin::loadColors(const Dataset<Points>& pointsColor, const std
                 localScalars[localColorIndex++] = scalars[globalIndex];
 
             std::swap(localScalars, scalars);
-           }
-        else if (validSelectionMapping.has_value() && validSelectionMapping.value() != nullptr) {
+        }
+        else if ( // only get map if derived check failed
+            const auto selectionMapping = getSelectionMapping(pointsColor, _positionDataset);
+            /* check if valid */ selectionMapping.has_value() && selectionMapping.value() != nullptr
+            )
+        {
             std::vector<float> localScalars(_numPoints, 0);
 
             // Map values like selection
-            const mv::SelectionMap::Map& linkedMap  = validSelectionMapping.value()->getMapping().getMap();
+            const mv::SelectionMap::Map& linkedMap  = selectionMapping.value()->getMapping().getMap();
             const std::uint32_t numPointsInTarget   = _positionDataset->getNumPoints();
 
             for (const auto& [fromID, vecOfIDs] : linkedMap) {

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -1,5 +1,6 @@
 #include "ScatterplotPlugin.h"
 
+#include "MappingUtils.h"
 #include "ScatterplotWidget.h"
 
 #include <Application.h>
@@ -45,107 +46,6 @@ Q_PLUGIN_METADATA(IID "studio.manivault.ScatterplotPlugin")
 
 using namespace mv;
 using namespace mv::util;
-
-// This only checks the immedeate parent and is deliberately not recursive
-// We might consider the latter in the future, but might need to cover edge cases
-static bool parentHasSameNumPoints(const mv::Dataset<DatasetImpl> data, const mv::Dataset<Points>& other) {
-    if (data->isDerivedData()) {
-        const auto parent = data->getParent();
-        if (parent->getDataType() == PointType) {
-            const auto parentPoints = mv::Dataset<Points>(parent);
-            return parentPoints->getNumPoints() == other->getNumPoints();
-        }
-    }
-    return false;
-}
-
-using CheckFunc = std::function<bool(const mv::LinkedData& linkedData, const mv::Dataset<Points>& target)>;
-
-static std::optional<const mv::LinkedData*> getSelectionMapping(const mv::Dataset<Points>& source, const mv::Dataset<Points>& target, CheckFunc checkMapping) {
-    const std::vector<mv::LinkedData>& linkedDatas = source->getLinkedData();
-
-    if (linkedDatas.empty())
-        return std::nullopt;
-
-    // find linked data between source and target OR source and target's parent, if target is derived and they have the same number of points
-    const auto it = std::ranges::find_if(linkedDatas, [&target, &checkMapping](const mv::LinkedData& linkedData) -> bool {
-        return checkMapping(linkedData, target);
-        });
-
-    if (it != linkedDatas.end()) {
-        return &(*it);  // return pointer to the found object
-    }
-
-    return std::nullopt; // nothing found
-}
-
-static std::optional<const mv::LinkedData*> getSelectionMappingColorsToPositions(const mv::Dataset<Points>& colors, const mv::Dataset<Points>& positions) {
-    auto testTargetAndParent = [](const mv::LinkedData& linkedData, const mv::Dataset<Points>& positions) -> bool {
-        const Dataset<DatasetImpl> mapTargetData = linkedData.getTargetDataset();
-        return mapTargetData == positions || parentHasSameNumPoints(mapTargetData, positions);
-    };
-    
-    return getSelectionMapping(colors, positions, testTargetAndParent);
-}
-
-static std::optional<const mv::LinkedData*> getSelectionMappingPositionsToColors(const mv::Dataset<Points>& positions, const mv::Dataset<Points>& colors) {
-    auto testTarget = [](const mv::LinkedData& linkedData, const mv::Dataset<Points>& colors) -> bool {
-        return linkedData.getTargetDataset() == colors;
-        };
-
-    auto mapping = getSelectionMapping(positions, colors, testTarget);
-
-    if (!mapping.has_value() && parentHasSameNumPoints(positions, positions)) {
-        const auto positionsParent = positions->getParent<Points>();
-        mapping = getSelectionMapping(positionsParent, colors, testTarget);
-    }
-
-    return mapping;
-}
-
-// Check if the mapping is surjective, i.e. hits all elements in the target
-static bool checkSurjectiveMapping(const mv::LinkedData& linkedData, const std::uint32_t numPointsInTarget) {
-    const std::map<std::uint32_t, std::vector<std::uint32_t>>& linkedMap = linkedData.getMapping().getMap();
-
-    std::vector<bool> found(numPointsInTarget, false);
-    std::uint32_t count = 0;
-
-    for (const auto& [key, vec] : linkedMap) {
-        for (std::uint32_t val : vec) {
-            if (val >= numPointsInTarget) continue; // Skip values that are too large
-
-            if (!found[val]) {
-                found[val] = true;
-                if (++count == numPointsInTarget)
-                    return true;
-            }
-        }
-    }
-
-    return false; // The previous loop would have returned early if the entire taget set was covered
-}
-
-// returns whether there is a selection map from colors to positions or positions to colors (or respective parents)
-// checks whether the mapping covers all elements in the target
-static bool checkSelectionMapping(const mv::Dataset<Points>& colors, const mv::Dataset<Points>& positions) {
-
-    // Check if there is a mapping
-    auto mapping = getSelectionMappingColorsToPositions(colors, positions);
-    auto numTargetPoints = positions->getNumPoints();
-
-    if (!mapping.has_value() || mapping.value() == nullptr) {
-
-        mapping = getSelectionMappingPositionsToColors(positions, colors);
-        numTargetPoints = colors->getNumPoints();
-
-        if (!mapping.has_value() || mapping.value() == nullptr)
-            return false;
-    }
-
-    const bool mappingCoversData = checkSurjectiveMapping(*(mapping.value()), numTargetPoints);
-
-    return mappingCoversData;
-}
 
 ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
     ViewPlugin(factory),

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -179,7 +179,10 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
                 // Accept for recoloring:
                 //  1. data with the same number of points
                 //  2. data which is derived from a parent that has the same number of points (e.g. for HSNE embeddings), where we can use global indices for mapping
-                //  3. data which has a fully-covering selection mapping to the position data (or it's parent), that we can use for setting colors
+                //  3. data which has a fully-covering selection mapping, that we can use for setting colors. Mapping in order of preference:
+                //      a) from color (or it's parent) to position
+                //      b) from color to position (or it's parent)
+                //      c) from source of position to color
 
                 // [1. Same number of points]
                 const auto numPointsCandidate   = candidateDataset->getNumPoints();
@@ -201,7 +204,6 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
                 }
 
                 // Accept for resizing and opacity: Only data with the same number of points
-
                 if (hasSameNumPoints) {
                     // Offer the option to use the points dataset as source for points size
                     dropRegions << new DropWidget::DropRegion(this, "Point size", QString("Size %1 points with %2").arg(_positionDataset->text(), candidateDataset->text()), "ruler-horizontal", true, [this, candidateDataset]() {
@@ -673,6 +675,7 @@ void ScatterplotPlugin::loadColors(const Dataset<Points>& pointsColor, const std
 
     // If number of points do not match, use a mapping
     // prefer global IDs (for derived data) over selection mapping
+    // prefer color to position over position to color over source of position to color
     if (numColorPoints != _numPoints) {
 
         std::vector<float> mappedColorScalars(_numPoints, std::numeric_limits<float>::lowest());

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -693,14 +693,14 @@ void ScatterplotPlugin::loadColors(const Dataset<Points>& pointsColor, const std
                 std::swap(localScalars, scalars);
             }
             else if ( // mapping from color data set to position data set
-                const auto selectionMapping = getSelectionMappingColorsToPositions(pointsColor, _positionDataset);
-                /* check if valid */ selectionMapping.has_value() && selectionMapping.value() != nullptr
+                const auto [selectionMapping, numPointsTarget] = getSelectionMappingColorsToPositions(pointsColor, _positionDataset);
+                /* check if valid */ selectionMapping != nullptr // && numPointsTarget == _numPoints
                 )
             {
                 std::vector<float> mappedScalars(_numPoints, 0);
 
                 // Map values like selection
-                const mv::SelectionMap::Map& linkedMap = selectionMapping.value()->getMapping().getMap();
+                const mv::SelectionMap::Map& linkedMap = selectionMapping->getMapping().getMap();
 
                 for (const auto& [fromColorID, vecOfPositionIDs] : linkedMap) {
                     for (std::uint32_t toPositionID : vecOfPositionIDs) {
@@ -711,14 +711,14 @@ void ScatterplotPlugin::loadColors(const Dataset<Points>& pointsColor, const std
                 std::swap(mappedScalars, scalars);
             }
             else if ( // mapping from position data set to color data set 
-                const auto selectionMapping = getSelectionMappingPositionsToColors(_positionDataset, pointsColor);
-                /* check if valid */ selectionMapping.has_value() && selectionMapping.value() != nullptr
+                const auto [selectionMapping, numPointsTarget] = getSelectionMappingPositionsToColors(_positionDataset, pointsColor);
+                /* check if valid */ selectionMapping != nullptr // && numPointsTarget == _numPoints
                 )
             {
                 std::vector<float> mappedScalars(_numPoints, std::numeric_limits<float>::lowest());
 
                 // Map values like selection (in reverse, use first value that occurs)
-                const mv::SelectionMap::Map& linkedMap = selectionMapping.value()->getMapping().getMap();
+                const mv::SelectionMap::Map& linkedMap = selectionMapping->getMapping().getMap();
 
                 for (const auto& [fromPositionID, vecOfColorIDs] : linkedMap) {
                     if (mappedScalars[fromPositionID] != std::numeric_limits<float>::lowest())


### PR DESCRIPTION
Follow-up to https://github.com/ManiVaultStudio/Scatterplot/pull/185

Currently points in the scatterplot can be recolored based on other data if the other data...
a. has the same number of points
b. is derived from a parent that has the same number of points (e.g. for HSNE embeddings)

This PR adds:
c. data which has a fully-covering selection mapping (linked data)

For mapping the colors from the color data to the point data we use in (b) the global indices and in (c) the linked data.

There are several possible mappings handled and checked in this order:
1. from color (or it's parent) to position
2. from color to position (or it's parent)
3. from source of position to color

This new feature is required for the Basal Ganglia project, specifically for recoloring HSNE and UMAP embeddings with means on cluster expression (these are the linked data).
Implementing mappings for opacity and size could be done similarly, but would not be nicely contained like here, since the opacity and size values are extracted in a different way at a different location in code.

