### PR TITLE
Call updateHeadsUpDisplay in fromVariantMap

### DIFF
--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -1006,7 +1006,7 @@ void ScatterplotPlugin::fromVariantMap(const QVariantMap& variantMap)
     _primaryToolbarAction.fromParentVariantMap(variantMap);
     _settingsAction.fromParentVariantMap(variantMap);
 
-    
+    updateHeadsUpDisplay();
 
     if (pointRenderer.getNavigator().getNavigationAction().getSerializationCountFrom() == 0) {
         qDebug() << "Resetting view";


### PR DESCRIPTION
`ScalarAction::sourceDataChanged` is not emitted when loading a scatterplot from a project. Therefore
```cpp
    connect(&_settingsAction.getPlotAction().getPointPlotAction().getSizeAction(), &ScalarAction::sourceDataChanged, this, &ScatterplotPlugin::updateHeadsUpDisplay);
    connect(&_settingsAction.getPlotAction().getPointPlotAction().getOpacityAction(), &ScalarAction::sourceDataChanged, this, &ScatterplotPlugin::updateHeadsUpDisplay);
```
from https://github.com/ManiVaultStudio/Scatterplot/pull/193 don't trigger `updateHeadsUpDisplay`.

We have to manually invoke `updateHeadsUpDisplay` in `fromVariantMap`