### PR TITLE
Add PDB file copying for Windows builds

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -146,6 +146,15 @@ class ScatterplotOPluginConan(ConanFile):
                 release_dir,
             ]
         )
+
+        # Add the pdb files next to the libs for RelWithDebInfo linking
+        if tools.os_info.is_windows:
+            pdb_dest = pathlib.Path(self.install_dir, "RelWithDebInfo/lib")
+            # pdb_dest.mkdir()
+            pdb_files = pathlib.Path(self.build_folder).glob("hdps/RelWithDebInfo/*.pdb")
+            for pfile in pdb_files:
+                shutil.copy(pfile, pdb_dest)
+        
         self.copy(pattern="*", src=package_dir)
 
     def package_info(self):


### PR DESCRIPTION
Copy PDB files to the RelWithDebInfo/lib directory on Windows.