### PR TITLE
Add check to stop being able to drop whatever cluster data on scatterplot data

### DIFF
--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -243,7 +243,7 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
                         // Check to set whether the number of data points comprised throughout all clusters is the same number
                         // as the number of data points in the dataset we are trying to color
                         int totalNumIndices = 0;
-                        for (Cluster cluster : candidateDataset->getClusters())
+                        for (const Cluster& cluster : candidateDataset->getClusters())
                         {
                             totalNumIndices += cluster.getIndices().size();
                         }


### PR DESCRIPTION
You basically have free reign right now to drop whatever cluster dataset you want on top of whatever data you are visualizing in the scatterplot. It could be cluster data from a completely different dataset.

This fix adds at least a check whether the total number of indices contained in the clusters matches the data you are visualizing. Before it would crash.