### PR TITLE
Handle derived data in cluster drop

### DIFF
--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -248,7 +248,13 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
                             totalNumIndices += cluster.getIndices().size();
                         }
 
-                        if (totalNumIndices == _positionDataset->getNumPoints())
+                        int totalNumPoints = 0;
+                        if (_positionDataset->isDerivedData())
+                            totalNumPoints = _positionSourceDataset->getFullDataset<Points>()->getNumPoints();
+                        else
+                            totalNumPoints = _positionDataset->getFullDataset<Points>()->getNumPoints();
+
+                        if (totalNumIndices == totalNumPoints)
                         {
                             // Use the clusters set for points color
                             dropRegions << new DropWidget::DropRegion(this, "Color", description, "palette", true, [this, candidateDataset]() {


### PR DESCRIPTION
`ScatterplotPlugin::loadColors` can handle the case when the shown point data and the incoming clusters are derived data. 
This occurs for example when you want to drop a cluster data on an HSNE refinement (and the clusters were defined wrt to the point data that the HSNE is based on)

We should allow this case when dropping clusters into the widget using the same number-of-point-checking logic.

https://github.com/ManiVaultStudio/Scatterplot/blob/f3e7e4395af945207fda68a8c665a78baee82909/src/ScatterplotPlugin.cpp#L812-L825