### PR TITLE
Fix HUD connection race

### DIFF
--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -339,6 +339,7 @@ void ScatterplotPlugin::init()
         updateHeadsUpDisplay();
     });
     connect(&_positionDataset, &Dataset<Points>::dataSelectionChanged, this, &ScatterplotPlugin::updateSelection);
+    connect(&_positionDataset, &Dataset<>::guiNameChanged, this, &ScatterplotPlugin::updateHeadsUpDisplay);
 
     _scatterPlotWidget->installEventFilter(this);
 
@@ -394,8 +395,6 @@ void ScatterplotPlugin::init()
 #endif
 
     updateHeadsUpDisplay();
-
-    connect(&_positionDataset, &Dataset<>::guiNameChanged, this, &ScatterplotPlugin::updateHeadsUpDisplay);
 
     const auto currentColorDatasetChanged = [this](Dataset<DatasetImpl> currentColorDataset) -> void {
         if (_colorDataset == currentColorDataset)

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -334,7 +334,10 @@ void ScatterplotPlugin::init()
     connect(&getSamplerAction(), &ViewPluginSamplerAction::sampleContextRequested, this, &ScatterplotPlugin::samplePoints);
 
     connect(&_positionDataset, &Dataset<Points>::changed, this, &ScatterplotPlugin::positionDatasetChanged);
-    connect(&_positionDataset, &Dataset<Points>::dataChanged, this, &ScatterplotPlugin::updateData);
+    connect(&_positionDataset, &Dataset<Points>::dataChanged, this, [this]() -> void {
+        updateData();
+        updateHeadsUpDisplay();
+    });
     connect(&_positionDataset, &Dataset<Points>::dataSelectionChanged, this, &ScatterplotPlugin::updateSelection);
 
     _scatterPlotWidget->installEventFilter(this);
@@ -392,7 +395,6 @@ void ScatterplotPlugin::init()
 
     updateHeadsUpDisplay();
 
-    connect(&_positionDataset, &Dataset<>::changed, this, &ScatterplotPlugin::updateHeadsUpDisplay);
     connect(&_positionDataset, &Dataset<>::guiNameChanged, this, &ScatterplotPlugin::updateHeadsUpDisplay);
 
     const auto currentColorDatasetChanged = [this](Dataset<DatasetImpl> currentColorDataset) -> void {

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -394,7 +394,6 @@ void ScatterplotPlugin::init()
 
     connect(&_positionDataset, &Dataset<>::changed, this, &ScatterplotPlugin::updateHeadsUpDisplay);
     connect(&_positionDataset, &Dataset<>::guiNameChanged, this, &ScatterplotPlugin::updateHeadsUpDisplay);
-    connect(&_positionDataset, &Dataset<>::guiNameChanged, this, &ScatterplotPlugin::updateHeadsUpDisplay);
 
     const auto currentColorDatasetChanged = [this](Dataset<DatasetImpl> currentColorDataset) -> void {
         if (_colorDataset == currentColorDataset)


### PR DESCRIPTION
In `ScatterplotPlugin::init()` we connect the `Dataset<Points>::changed` signal from `_positionDataset` twice, to both `updateData()` and `updateHeadsUpDisplay()` - this seems to result in a different call order on linux with gcc compared to Windows with MSVC, which ultimately yields a memory issue and causes a crash when loading data into the scatterplot. This PR bundles the calls to force consistent calling order.

Also `_positionDataset`'s signal, `Dataset<>::guiNameChanged` is connected twice to `updateHeadsUpDisplay()`, we only need to do this once.

To prevent duplication I refactored `init()` such that all the connections are grouped.