### PR TITLE
Reset auxiliary dataset picker actions

### DIFF
--- a/src/DatasetsAction.cpp
+++ b/src/DatasetsAction.cpp
@@ -42,15 +42,24 @@ DatasetsAction::DatasetsAction(QObject* parent, const QString& title) :
 
     setupDatasetPickerActions(scatterplotPlugin);
 
-    connect(&_positionDatasetPickerAction, &DatasetPickerAction::datasetPicked, [this, scatterplotPlugin](Dataset<DatasetImpl> pickedDataset) -> void {
+    const auto invalidateFilters = [this, scatterplotPlugin]() -> void {
         _colorDatasetPickerAction.invalidateFilter();
         _pointSizeDatasetPickerAction.invalidateFilter();
         _pointOpacityDatasetPickerAction.invalidateFilter();
+    };
+
+    connect(&_positionDatasetPickerAction, &DatasetPickerAction::datasetPicked, [this, scatterplotPlugin, invalidateFilters](Dataset<DatasetImpl> pickedDataset) -> void {
+        invalidateFilters();
     });
 
-    _colorDatasetPickerAction.invalidateFilter();
-    _pointSizeDatasetPickerAction.invalidateFilter();
-    _pointOpacityDatasetPickerAction.invalidateFilter();
+    const auto resetAuxilliaryDatasets = [this]() -> void {
+        _colorDatasetPickerAction.setCurrentIndex(-1);
+		_pointSizeDatasetPickerAction.setCurrentIndex(-1);
+		_pointOpacityDatasetPickerAction.setCurrentIndex(-1);
+	};
+
+    connect(&scatterplotPlugin->getPositionDataset(), &Dataset<Points>::changed, this, resetAuxilliaryDatasets);
+    connect(&scatterplotPlugin->getPositionSourceDataset(), &Dataset<Points>::changed, this, resetAuxilliaryDatasets);
 }
 
 void DatasetsAction::connectToPublicAction(WidgetAction* publicAction, bool recursive)


### PR DESCRIPTION
This pull request refactors the way auxiliary dataset picker actions are managed in `DatasetsAction.cpp`. Instead of invalidating filters and resetting indices directly in the constructor, the code now uses lambda functions and signal connections to ensure these actions are triggered automatically when relevant datasets change. This improves maintainability and ensures the UI remains consistent with the underlying data.

**Refactoring of dataset picker actions:**

* Introduced the `invalidateFilters` lambda to centralize the logic for invalidating filters on auxiliary dataset picker actions, and connected it to the position dataset picker's `datasetPicked` signal.
* Added the `resetAuxilliaryDatasets` lambda to reset the selected indices of auxiliary dataset picker actions, and connected it to the `changed` signals of both the position and position source datasets.
* Removed direct calls to invalidate filters from the constructor, relying instead on the new signal-based approach.