### PR TITLE
Solve plugin destruction crash by avoiding Qt double deletion 

### DIFF
--- a/src/DatasetsAction.cpp
+++ b/src/DatasetsAction.cpp
@@ -28,7 +28,7 @@ DatasetsAction::DatasetsAction(QObject* parent, const QString& title) :
     if (scatterplotPlugin == nullptr)
         return;
 
-    auto& settingsAction    = scatterplotPlugin->getSettingsAction();
+    auto& settingsAction    = *dynamic_cast<SettingsAction*>(parent);
     auto& plotAction        = settingsAction.getPlotAction();
     auto& pointPlotAction   = plotAction.getPointPlotAction();
 
@@ -132,7 +132,7 @@ void DatasetsAction::setupPositionDatasetPickerAction(ScatterplotPlugin* scatter
 
 void DatasetsAction::setupColorDatasetPickerAction(ScatterplotPlugin* scatterplotPlugin)
 {
-    auto& settingsAction = scatterplotPlugin->getSettingsAction();
+    auto& settingsAction = *dynamic_cast<SettingsAction*>(parent());
 
     _colorDatasetPickerAction.setFilterFunction([this, scatterplotPlugin](mv::Dataset<DatasetImpl> dataset) -> bool {
         if (!(dataset->getDataType() == PointType || dataset->getDataType() == ColorType || dataset->getDataType() == ClusterType))

--- a/src/DensityPlotAction.cpp
+++ b/src/DensityPlotAction.cpp
@@ -30,7 +30,7 @@ void DensityPlotAction::initialize(ScatterplotPlugin* scatterplotPlugin)
     _scatterplotPlugin = scatterplotPlugin;
 
     const auto computeDensity = [this]() -> void {
-        if (static_cast<std::int32_t>(_scatterplotPlugin->getSettingsAction().getRenderModeAction().getCurrentIndex()) == ScatterplotWidget::RenderMode::SCATTERPLOT)
+        if (static_cast<std::int32_t>(dynamic_cast<SettingsAction*>(parent()->parent())->getRenderModeAction().getCurrentIndex()) == ScatterplotWidget::RenderMode::SCATTERPLOT)
             return;
 
         _scatterplotPlugin->getScatterplotWidget().setSigma(_sigmaAction.getValue());
@@ -38,7 +38,7 @@ void DensityPlotAction::initialize(ScatterplotPlugin* scatterplotPlugin)
         const auto maxDensity = _scatterplotPlugin->getScatterplotWidget().getDensityRenderer().getMaxDensity();
 
         if (maxDensity > 0)
-            _scatterplotPlugin->getSettingsAction().getColoringAction().getColorMap1DAction().getRangeAction(ColorMapAction::Axis::X).setRange({ 0.0f, maxDensity });
+            dynamic_cast<SettingsAction*>(parent()->parent())->getColoringAction().getColorMap1DAction().getRangeAction(ColorMapAction::Axis::X).setRange({ 0.0f, maxDensity });
     };
 
     connect(&_sigmaAction, &DecimalAction::valueChanged, this, computeDensity);
@@ -59,7 +59,7 @@ void DensityPlotAction::initialize(ScatterplotPlugin* scatterplotPlugin)
         computeDensity();
     });
 
-    connect(&_scatterplotPlugin->getSettingsAction().getRenderModeAction(), &OptionAction::currentIndexChanged, this, computeDensity);
+    connect(&dynamic_cast<SettingsAction*>(parent()->parent())->getRenderModeAction(), &OptionAction::currentIndexChanged, this, computeDensity);
 
     updateSigmaAction();
     computeDensity();

--- a/src/ScatterplotPlugin.cpp
+++ b/src/ScatterplotPlugin.cpp
@@ -50,8 +50,8 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
     _dropWidget(nullptr),
     _scatterPlotWidget(new ScatterplotWidget(this)),
     _numPoints(0),
-    _settingsAction(this, "Settings"),
-    _primaryToolbarAction(this, "Primary Toolbar")
+    _settingsAction(new SettingsAction(this, "Settings")),
+    _primaryToolbarAction(new HorizontalToolbarAction(this, "Primary Toolbar"))
 {
     setObjectName("Scatterplot");
 
@@ -83,25 +83,25 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
 
     getWidget().setFocusPolicy(Qt::ClickFocus);
 
-    _primaryToolbarAction.addAction(&_settingsAction.getDatasetsAction());
-    _primaryToolbarAction.addAction(&_settingsAction.getRenderModeAction(), 3, GroupAction::Horizontal);
-    _primaryToolbarAction.addAction(&_settingsAction.getPositionAction(), 1, GroupAction::Horizontal);
-    _primaryToolbarAction.addAction(&_settingsAction.getPlotAction(), 2, GroupAction::Horizontal);
-    _primaryToolbarAction.addAction(&_settingsAction.getColoringAction());
-    _primaryToolbarAction.addAction(&_settingsAction.getSubsetAction());
-    _primaryToolbarAction.addAction(&_settingsAction.getClusteringAction());
-    _primaryToolbarAction.addAction(&_settingsAction.getSelectionAction());
-    _primaryToolbarAction.addAction(&getSamplerAction());
+    _primaryToolbarAction->addAction(&_settingsAction->getDatasetsAction());
+    _primaryToolbarAction->addAction(&_settingsAction->getRenderModeAction(), 3, GroupAction::Horizontal);
+    _primaryToolbarAction->addAction(&_settingsAction->getPositionAction(), 1, GroupAction::Horizontal);
+    _primaryToolbarAction->addAction(&_settingsAction->getPlotAction(), 2, GroupAction::Horizontal);
+    _primaryToolbarAction->addAction(&_settingsAction->getColoringAction());
+    _primaryToolbarAction->addAction(&_settingsAction->getSubsetAction());
+    _primaryToolbarAction->addAction(&_settingsAction->getClusteringAction());
+    _primaryToolbarAction->addAction(&_settingsAction->getSelectionAction());
+    _primaryToolbarAction->addAction(&getSamplerAction());
 
     auto focusSelectionAction = new ToggleAction(this, "Focus selection");
 
     focusSelectionAction->setIconByName("mouse-pointer");
 
     connect(focusSelectionAction, &ToggleAction::toggled, this, [this](bool toggled) -> void {
-        _settingsAction.getPlotAction().getPointPlotAction().getFocusSelection().setChecked(toggled);
+        _settingsAction->getPlotAction().getPointPlotAction().getFocusSelection().setChecked(toggled);
     });
 
-    connect(&_settingsAction.getPlotAction().getPointPlotAction().getFocusSelection(), &ToggleAction::toggled, this, [this, focusSelectionAction](bool toggled) -> void {
+    connect(&_settingsAction->getPlotAction().getPointPlotAction().getFocusSelection(), &ToggleAction::toggled, this, [this, focusSelectionAction](bool toggled) -> void {
         focusSelectionAction->setChecked(toggled);
     });
 
@@ -114,13 +114,13 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
     connect(_scatterPlotWidget, &ScatterplotWidget::renderModeChanged, this, updateReadOnly);
     connect(&_positionDataset, &Dataset<Points>::changed, this, updateReadOnly);
 
-    //_secondaryToolbarAction.addAction(&_settingsAction.getMiscellaneousAction());
+    //_secondaryToolbarAction.addAction(&_settingsAction->getMiscellaneousAction());
 
     connect(_scatterPlotWidget, &ScatterplotWidget::customContextMenuRequested, this, [this](const QPoint& point) {
         if (!_positionDataset.isValid())
             return;
 
-        auto contextMenu = _settingsAction.getContextMenu();
+        auto contextMenu = _settingsAction->getContextMenu();
 
         contextMenu->addSeparator();
 
@@ -165,7 +165,7 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
                 // Load as point positions when no dataset is currently loaded
                 dropRegions << new DropWidget::DropRegion(this, "Point position", description, "map-marker-alt", true, [this, candidateDataset]() {
                     _positionDataset = candidateDataset;
-                    _settingsAction.getColoringAction().setCurrentColorDataset(nullptr);
+                    _settingsAction->getColoringAction().setCurrentColorDataset(nullptr);
                 });
             }
             else {
@@ -174,7 +174,7 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
                     // The number of points is equal, so offer the option to replace the existing points dataset
                     dropRegions << new DropWidget::DropRegion(this, "Point position", description, "map-marker-alt", true, [this, candidateDataset]() {
                         _positionDataset = candidateDataset;
-                        _settingsAction.getColoringAction().setCurrentColorDataset(nullptr);
+                        _settingsAction->getColoringAction().setCurrentColorDataset(nullptr);
                     });
 				}
 
@@ -200,7 +200,7 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
                 if (hasSameNumPoints || hasSameNumPointsAsFull || hasSelectionMapping) {
                     // Offer the option to use the points dataset as source for points colors
                     dropRegions << new DropWidget::DropRegion(this, "Point color", QString("Colorize %1 points with %2").arg(_positionDataset->text(), candidateDataset->text()), "palette", true, [this, candidateDataset]() {
-                        _settingsAction.getColoringAction().setCurrentColorDataset(candidateDataset);   // calls addColorDataset internally
+                        _settingsAction->getColoringAction().setCurrentColorDataset(candidateDataset);   // calls addColorDataset internally
                         });
 
                 }
@@ -209,12 +209,12 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
                 if (hasSameNumPoints) {
                     // Offer the option to use the points dataset as source for points size
                     dropRegions << new DropWidget::DropRegion(this, "Point size", QString("Size %1 points with %2").arg(_positionDataset->text(), candidateDataset->text()), "ruler-horizontal", true, [this, candidateDataset]() {
-                        _settingsAction.getPlotAction().getPointPlotAction().setCurrentPointSizeDataset(candidateDataset);
+                        _settingsAction->getPlotAction().getPointPlotAction().setCurrentPointSizeDataset(candidateDataset);
                         });
 
                     // Offer the option to use the points dataset as source for points opacity
                     dropRegions << new DropWidget::DropRegion(this, "Point opacity", QString("Set %1 points opacity with %2").arg(_positionDataset->text(), candidateDataset->text()), "brush", true, [this, candidateDataset]() {
-                        _settingsAction.getPlotAction().getPointPlotAction().setCurrentPointOpacityDataset(candidateDataset);
+                        _settingsAction->getPlotAction().getPointPlotAction().setCurrentPointOpacityDataset(candidateDataset);
                         });
                 }
             }
@@ -232,11 +232,11 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
             // Only allow user to color by clusters when there is a positions dataset loaded
             if (_positionDataset.isValid()) {
 
-                if (_settingsAction.getColoringAction().hasColorDataset(candidateDataset)) {
+                if (_settingsAction->getColoringAction().hasColorDataset(candidateDataset)) {
 
                     // The clusters dataset is already loaded
                     dropRegions << new DropWidget::DropRegion(this, "Color", description, "palette", true, [this, candidateDataset]() {
-                        _settingsAction.getColoringAction().setCurrentColorDataset(candidateDataset);
+                        _settingsAction->getColoringAction().setCurrentColorDataset(candidateDataset);
                         });
                 }
                 else {
@@ -260,8 +260,8 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
                         {
                             // Use the clusters set for points color
                             dropRegions << new DropWidget::DropRegion(this, "Color", description, "palette", true, [this, candidateDataset]() {
-                                _settingsAction.getColoringAction().addColorDataset(candidateDataset);
-                                _settingsAction.getColoringAction().setCurrentColorDataset(candidateDataset);
+                                _settingsAction->getColoringAction().addColorDataset(candidateDataset);
+                                _settingsAction->getColoringAction().setCurrentColorDataset(candidateDataset);
                             });
                         }
                         else
@@ -282,7 +282,7 @@ ScatterplotPlugin::ScatterplotPlugin(const PluginFactory* factory) :
         return dropRegions;
     });
 
-    auto& selectionAction = _settingsAction.getSelectionAction();
+    auto& selectionAction = _settingsAction->getSelectionAction();
 
     getSamplerAction().initialize(this, &selectionAction.getPixelSelectionAction(), &selectionAction.getSamplerPixelSelectionAction());
     getSamplerAction().getEnabledAction().setChecked(false);
@@ -306,7 +306,7 @@ void ScatterplotPlugin::init()
 
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
-    layout->addWidget(_primaryToolbarAction.createWidget(&getWidget()));
+    layout->addWidget(_primaryToolbarAction->createWidget(&getWidget()));
     layout->addWidget(_scatterPlotWidget, 100);
 
     auto& navigationAction = _scatterPlotWidget->getPointRendererNavigator().getNavigationAction();
@@ -315,7 +315,7 @@ void ScatterplotPlugin::init()
         layout->addWidget(navigationWidget);
         layout->setAlignment(navigationWidget, Qt::AlignCenter);
 
-        navigationAction.setParent(&_settingsAction);
+        navigationAction.setParent(_settingsAction);
     }
 
     getWidget().setLayout(layout);
@@ -345,7 +345,7 @@ void ScatterplotPlugin::init()
     connect(&_positionDataset, &Dataset<Points>::dataSelectionChanged, this, &ScatterplotPlugin::updateSelection);
     connect(&_positionDataset, &Dataset<>::guiNameChanged, this, &ScatterplotPlugin::updateHeadsUpDisplay);
 
-    connect(&_settingsAction.getMiscellaneousAction().getBackgroundColorAction(), &ColorAction::colorChanged, this, &ScatterplotPlugin::updateHeadsUpDisplayTextColor);
+    connect(&_settingsAction->getMiscellaneousAction().getBackgroundColorAction(), &ColorAction::colorChanged, this, &ScatterplotPlugin::updateHeadsUpDisplayTextColor);
 
     connect(&getScatterplotWidget().getPointRendererNavigator().getNavigationAction().getZoomSelectionAction(), &TriggerAction::triggered, this, [this]() -> void {
         if (_selectionBoundaries.isValid())
@@ -400,8 +400,8 @@ void ScatterplotPlugin::init()
         });
 #endif
 
-    auto& datasetsAction    = _settingsAction.getDatasetsAction();
-    auto& pointPlotAction   = _settingsAction.getPlotAction().getPointPlotAction();
+    auto& datasetsAction    = _settingsAction->getDatasetsAction();
+    auto& pointPlotAction   = _settingsAction->getPlotAction().getPointPlotAction();
 
     connect(&datasetsAction.getPositionDatasetPickerAction(), &DatasetPickerAction::currentIndexChanged, this, &ScatterplotPlugin::updateHeadsUpDisplay);
     connect(&datasetsAction.getColorDatasetPickerAction(), &DatasetPickerAction::currentIndexChanged, this, &ScatterplotPlugin::updateHeadsUpDisplay);
@@ -419,11 +419,11 @@ void ScatterplotPlugin::init()
         datasetsAction.invalidateDatasetPickerActionFilters();
     }
 
-    connect(&_settingsAction.getPlotAction().getPointPlotAction().getSizeAction(), &ScalarAction::sourceDataChanged, this, [this]() -> void {
+    connect(&_settingsAction->getPlotAction().getPointPlotAction().getSizeAction(), &ScalarAction::sourceDataChanged, this, [this]() -> void {
 	    _scatterPlotWidget->update();
     });
 
-    connect(&_settingsAction.getPlotAction().getPointPlotAction().getOpacityAction(), &ScalarAction::sourceDataChanged, this, [this]() -> void {
+    connect(&_settingsAction->getPlotAction().getPointPlotAction().getOpacityAction(), &ScalarAction::sourceDataChanged, this, [this]() -> void {
         _scatterPlotWidget->update();
         });
 }
@@ -438,7 +438,7 @@ void ScatterplotPlugin::loadData(const Datasets& datasets)
     _positionDataset = datasets.first();
 
     // And set the coloring mode to constant
-    _settingsAction.getColoringAction().getColorByAction().setCurrentIndex(0);
+    _settingsAction->getColoringAction().getColorByAction().setCurrentIndex(0);
 }
 
 void ScatterplotPlugin::createSubset(const bool& fromSourceData /*= false*/, const QString& name /*= ""*/)
@@ -463,7 +463,7 @@ void ScatterplotPlugin::selectPoints()
 
     auto& pixelSelectionTool = _scatterPlotWidget->getPixelSelectionTool();
 
-    auto  renderer = _settingsAction.getRenderModeAction().getCurrentIndex() > 0 ? dynamic_cast<Renderer2D*>(&_scatterPlotWidget->_densityRenderer) : dynamic_cast<Renderer2D*>(&_scatterPlotWidget->_pointRenderer);
+    auto  renderer = _settingsAction->getRenderModeAction().getCurrentIndex() > 0 ? dynamic_cast<Renderer2D*>(&_scatterPlotWidget->_densityRenderer) : dynamic_cast<Renderer2D*>(&_scatterPlotWidget->_pointRenderer);
     auto& navigator = renderer->getNavigator();
 
     // Only proceed with a valid points position dataset and when the pixel selection tool is active
@@ -662,11 +662,11 @@ void ScatterplotPlugin::samplePoints()
 
     _scatterPlotWidget->update();
 
-    auto& coloringAction = _settingsAction.getColoringAction();
+    auto& coloringAction = _settingsAction->getColoringAction();
 
     getSamplerAction().setSampleContext({
         { "PositionDatasetID", _positionDataset.getDatasetId() },
-        { "ColorDatasetID", _settingsAction.getColoringAction().getCurrentColorDataset().getDatasetId() },
+        { "ColorDatasetID", _settingsAction->getColoringAction().getCurrentColorDataset().getDatasetId() },
         { "LocalPointIndices", localPointIndices },
         { "GlobalPointIndices", globalPointIndices },
         { "Distances", distances },
@@ -675,7 +675,7 @@ void ScatterplotPlugin::samplePoints()
         { "ColorMap1D", coloringAction.getColorMap1DAction().getColorMapImage() },
         { "ColorMap2D", coloringAction.getColorMap2DAction().getColorMapImage() },
         { "ColorDimensionIndex", coloringAction.getDimensionAction().getCurrentDimensionAction().getCurrentIndex() },
-        { "RenderMode", _settingsAction.getRenderModeAction().getCurrentText() }
+        { "RenderMode", _settingsAction->getRenderModeAction().getCurrentText() }
     });
 }
 
@@ -815,12 +815,12 @@ void ScatterplotPlugin::loadColors(const Dataset<Points>& pointsColor, const std
         }
         catch (const std::exception& e) {
             qDebug() << "ScatterplotPlugin::loadColors: mapping failed -> " << e.what();
-            _settingsAction.getColoringAction().getColorByAction().setCurrentIndex(0);  // reset to color by constant
+            _settingsAction->getColoringAction().getColorByAction().setCurrentIndex(0);  // reset to color by constant
             return;
         }
         catch (...) {
             qDebug() << "ScatterplotPlugin::loadColors: mapping failed for an unknown reason.";
-            _settingsAction.getColoringAction().getColorByAction().setCurrentIndex(0);  // reset to color by constant
+            _settingsAction->getColoringAction().getColorByAction().setCurrentIndex(0);  // reset to color by constant
             return;
         }
 
@@ -833,7 +833,7 @@ void ScatterplotPlugin::loadColors(const Dataset<Points>& pointsColor, const std
     _scatterPlotWidget->setScalars(colorScalars);
     _scatterPlotWidget->setScalarEffect(PointEffect::Color);
 
-    _settingsAction.getColoringAction().updateColorMapActionScalarRange();
+    _settingsAction->getColoringAction().updateColorMapActionScalarRange();
 
     // Render
     getWidget().update();
@@ -913,8 +913,8 @@ void ScatterplotPlugin::updateData()
     if (_positionDataset.isValid()) {
 
         // Get the selected dimensions to use as X and Y dimension in the plot
-        const auto xDim = _settingsAction.getPositionAction().getDimensionX();
-        const auto yDim = _settingsAction.getPositionAction().getDimensionY();
+        const auto xDim = _settingsAction->getPositionAction().getDimensionX();
+        const auto yDim = _settingsAction->getPositionAction().getDimensionY();
 
         // If one of the dimensions was not set, do not draw anything
         if (xDim < 0 || yDim < 0)
@@ -923,8 +923,8 @@ void ScatterplotPlugin::updateData()
         // Ensure that if positionDataset has now more points, the additional points are plotted
         if (_numPoints != _positionDataset->getNumPoints())
         {
-            _settingsAction.getPlotAction().getPointPlotAction().updateScatterPlotWidgetPointSizeScalars();
-            _settingsAction.getPlotAction().getPointPlotAction().updateScatterPlotWidgetPointOpacityScalars();
+            _settingsAction->getPlotAction().getPointPlotAction().updateScatterPlotWidgetPointSizeScalars();
+            _settingsAction->getPlotAction().getPointPlotAction().updateScatterPlotWidgetPointOpacityScalars();
         }
 
         // Determine number of points depending on if its a full dataset or a subset
@@ -1002,11 +1002,11 @@ void ScatterplotPlugin::updateSelection()
 
         _scatterPlotWidget->update();
 
-        auto& coloringAction = _settingsAction.getColoringAction();
+        auto& coloringAction = _settingsAction->getColoringAction();
 
         getSamplerAction().setSampleContext({
             { "PositionDatasetID", _positionDataset.getDatasetId() },
-            { "ColorDatasetID", _settingsAction.getColoringAction().getCurrentColorDataset().getDatasetId() },
+            { "ColorDatasetID", _settingsAction->getColoringAction().getCurrentColorDataset().getDatasetId() },
             { "LocalPointIndices", localPointIndices },
             { "GlobalPointIndices", globalPointIndices },
             { "Distances", QVariantList()},
@@ -1015,7 +1015,7 @@ void ScatterplotPlugin::updateSelection()
             { "ColorMap1D", coloringAction.getColorMap1DAction().getColorMapImage() },
             { "ColorMap2D", coloringAction.getColorMap2DAction().getColorMapImage() },
             { "ColorDimensionIndex", coloringAction.getDimensionAction().getCurrentDimensionAction().getCurrentIndex() },
-            { "RenderMode", _settingsAction.getRenderModeAction().getCurrentText() }
+            { "RenderMode", _settingsAction->getRenderModeAction().getCurrentText() }
 		});
     }
 }
@@ -1027,7 +1027,7 @@ void ScatterplotPlugin::updateHeadsUpDisplay()
 
     getHeadsUpDisplayAction().removeAllHeadsUpDisplayItems();
 
-    auto& coloringAction = _settingsAction.getColoringAction();
+    auto& coloringAction = _settingsAction->getColoringAction();
 
     if (_positionDataset.isValid()) {
         const auto datasetsItem = getHeadsUpDisplayAction().addHeadsUpDisplayItem("Datasets", "", "");
@@ -1042,7 +1042,7 @@ void ScatterplotPlugin::updateHeadsUpDisplay()
         if (coloringAction.getColorByAction().getCurrentIndex() >= 2)
 			addMetaDataToHeadsUpDisplay("Color", coloringAction.getCurrentColorDataset(), datasetsItem);
 
-        auto& pointPlotAction = _settingsAction.getPlotAction().getPointPlotAction();
+        auto& pointPlotAction = _settingsAction->getPlotAction().getPointPlotAction();
 
         //qDebug() << "ScatterplotPlugin::updateHeadsUpDisplay: point size dataset: " << pointPlotAction.getSizeAction().getCurrentDataset().isValid() << ", opacity dataset: " << pointPlotAction.getOpacityAction().getCurrentDataset().isValid();
         addMetaDataToHeadsUpDisplay("Size",    pointPlotAction.getSizeAction().getCurrentDataset(), datasetsItem);
@@ -1058,7 +1058,7 @@ void ScatterplotPlugin::updateHeadsUpDisplayTextColor()
         if (auto headsUpDisplayWidgetTreeView = headsUpDisplayWidget->findChild<QTreeView*>("TreeView")) {
             QPalette palette = headsUpDisplayWidgetTreeView->palette();
 
-            palette.setColor(QPalette::Text, _settingsAction.getMiscellaneousAction().getBackgroundColorAction().getColor().lightnessF() > .5f ? Qt::black : Qt::white);
+            palette.setColor(QPalette::Text, _settingsAction->getMiscellaneousAction().getBackgroundColorAction().getColor().lightnessF() > .5f ? Qt::black : Qt::white);
 
             headsUpDisplayWidgetTreeView->setPalette(palette);
         }
@@ -1075,8 +1075,8 @@ void ScatterplotPlugin::fromVariantMap(const QVariantMap& variantMap)
 
     pointRenderer.getNavigator().resetView(true);
 
-    _primaryToolbarAction.fromParentVariantMap(variantMap);
-    _settingsAction.fromParentVariantMap(variantMap);
+    _primaryToolbarAction->fromParentVariantMap(variantMap);
+    _settingsAction->fromParentVariantMap(variantMap);
 
     if (pointRenderer.getNavigator().getNavigationAction().getSerializationCountFrom() == 0) {
         _scatterPlotWidget->update();
@@ -1089,8 +1089,8 @@ QVariantMap ScatterplotPlugin::toVariantMap() const
 {
     QVariantMap variantMap = ViewPlugin::toVariantMap();
 
-    _primaryToolbarAction.insertIntoVariantMap(variantMap);
-    _settingsAction.insertIntoVariantMap(variantMap);
+    _primaryToolbarAction->insertIntoVariantMap(variantMap);
+    _settingsAction->insertIntoVariantMap(variantMap);
 
     return variantMap;
 }

--- a/src/ScatterplotPlugin.h
+++ b/src/ScatterplotPlugin.h
@@ -88,7 +88,7 @@ public:
     /** Get reference to the scatter plot widget */
     ScatterplotWidget& getScatterplotWidget();
 
-    SettingsAction& getSettingsAction() { return _settingsAction; }
+    SettingsAction& getSettingsAction() { return *_settingsAction; }
 
 private:
     void updateData();
@@ -114,15 +114,15 @@ public: // Serialization
     QVariantMap toVariantMap() const override;
 
 private:
-    mv::gui::DropWidget*            _dropWidget;                /** Widget for dropping datasets */
-    ScatterplotWidget*              _scatterPlotWidget;         /** The visualization widget */
-    Dataset<Points>                 _positionDataset;           /** Smart pointer to points dataset for point position */
-    Dataset<Points>                 _positionSourceDataset;     /** Smart pointer to source of the points dataset for point position (if any) */
-    std::vector<mv::Vector2f>       _positions;                 /** Point positions */
-    unsigned int                    _numPoints;                 /** Number of point positions */
-    SettingsAction                  _settingsAction;            /** Group action for all settings */
-    HorizontalToolbarAction         _primaryToolbarAction;      /** Horizontal toolbar for primary content */
-    QRectF                          _selectionBoundaries;       /** Boundaries of the selection */
+    mv::gui::DropWidget*                _dropWidget;                /** Widget for dropping datasets */
+    ScatterplotWidget*                  _scatterPlotWidget;         /** The visualization widget */
+    Dataset<Points>                     _positionDataset;           /** Smart pointer to points dataset for point position */
+    Dataset<Points>                     _positionSourceDataset;     /** Smart pointer to source of the points dataset for point position (if any) */
+    std::vector<mv::Vector2f>           _positions;                 /** Point positions */
+    unsigned int                        _numPoints;                 /** Number of point positions */
+    QPointer<SettingsAction>            _settingsAction;            /** Group action for all settings */
+    QPointer<HorizontalToolbarAction>   _primaryToolbarAction;      /** Horizontal toolbar for primary content */
+    QRectF                              _selectionBoundaries;       /** Boundaries of the selection */
 
     static const std::int32_t LAZY_UPDATE_INTERVAL = 2;
 


### PR DESCRIPTION
This pull request refactors how `SettingsAction` and `HorizontalToolbarAction` are managed within `ScatterplotPlugin` and related classes. The main change is converting these from value members to pointer members, which requires updating how they are accessed throughout the codebase. Additionally, there are updates to how parent-child relationships are handled for these actions, and several instances now use `dynamic_cast` to retrieve the correct parent action. These changes improve object lifetime management and align with Qt best practices.

Key changes include:

**Refactoring to Pointer Members:**

* Converted `_settingsAction` and `_primaryToolbarAction` in `ScatterplotPlugin` from value members to pointer members, updating all usages to use pointer syntax (`->` instead of `.`). [[1]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL53-R54) [[2]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL86-R104) [[3]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL117-R123) [[4]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL168-R168) [[5]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL177-R177) [[6]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL203-R203) [[7]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL212-R217) [[8]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL235-R239) [[9]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL263-R264) [[10]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL285-R285) [[11]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL309-R309) [[12]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL318-R318) [[13]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL348-R348) [[14]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL403-R404) [[15]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL422-R426) [[16]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL441-R441) [[17]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL466-R466) [[18]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL665-R669) [[19]](diffhunk://#diff-48b414cb2b57301f5f609e890bef24db869b82cfcb15057d760bcb90852ad0feL678-R678)

**Parent/Child Relationship and Action Access:**

* Updated constructors and methods to use `dynamic_cast` to retrieve `SettingsAction*` from the parent where appropriate, improving type safety and clarity. [[1]](diffhunk://#diff-ac5aa0cc37a19df5188882a5486f802d871f659b1b84f69f7839eff5f4b90939L31-R31) [[2]](diffhunk://#diff-ac5aa0cc37a19df5188882a5486f802d871f659b1b84f69f7839eff5f4b90939L135-R135) [[3]](diffhunk://#diff-455eab9491e191272e1ba88e271e4ba9710210110f15ca15566c845ce032fb84L33-R41) [[4]](diffhunk://#diff-455eab9491e191272e1ba88e271e4ba9710210110f15ca15566c845ce032fb84L62-R62)

These changes modernize the code and reduce the risk of object slicing or lifetime issues, making the codebase more robust and maintainable.