### PR TITLE
Use `mv_project_defaults()` for setting CMake defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,17 +15,8 @@ PROJECT(${PROJECT}
 # -----------------------------------------------------------------------------
 # CMake Options
 # -----------------------------------------------------------------------------
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOMOC ON)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /EHsc /W3 /MP /permissive- /Zc:__cplusplus")
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MD")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD")
-endif()
 
 # -----------------------------------------------------------------------------
 # Dependencies
@@ -33,6 +24,7 @@ endif()
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets OpenGL OpenGLWidgets REQUIRED)
 
 find_package(ManiVault COMPONENTS Core PointData ClusterData ColorData ImageData CONFIG QUIET)
+mv_project_defaults()
 
 # -----------------------------------------------------------------------------
 # Source files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ PROJECT(${PROJECT}
 # CMake Options
 # -----------------------------------------------------------------------------
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
 
 # -----------------------------------------------------------------------------
 # Dependencies
@@ -109,6 +108,7 @@ target_include_directories(${PROJECT} PRIVATE "${ManiVault_INCLUDE_DIR}")
 target_compile_features(${PROJECT} PRIVATE cxx_std_20)
 
 set_target_properties(${PROJECT} PROPERTIES 
+    AUTOMOC ON
     UNITY_BUILD ${MV_UNITY_BUILD}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,9 +108,9 @@ target_include_directories(${PROJECT} PRIVATE "${ManiVault_INCLUDE_DIR}")
 # -----------------------------------------------------------------------------
 target_compile_features(${PROJECT} PRIVATE cxx_std_20)
 
-if(MV_UNITY_BUILD)
-    set_target_properties(${PROJECT} PROPERTIES UNITY_BUILD ON)
-endif()
+set_target_properties(${PROJECT} PROPERTIES 
+    UNITY_BUILD ${MV_UNITY_BUILD}
+)
 
 # -----------------------------------------------------------------------------
 # Target library linking

--- a/conanfile.py
+++ b/conanfile.py
@@ -105,7 +105,7 @@ class ScatterplotOPluginConan(ConanFile):
         tc.variables["ManiVault_DIR"] = manivault_dir
 
         # Set some build options
-        tc.variables["MV_UNITY_BUILD"] = "ON"
+        tc.cache_variables["MV_UNITY_BUILD"] = True
 
         tc.generate()
 


### PR DESCRIPTION
Use `mv_project_defaults()` as introduced in https://github.com/ManiVaultStudio/core/pull/1240.

Drive-by:
- Remove unused `CMAKE_AUTORCC` and `CMAKE_MODULE_PATH`
- Simplify unity build setup
- Prefer target based `AUTOMOC` property